### PR TITLE
Fix retain cycle

### DIFF
--- a/Demo/SVPullToRefreshDemo.xcodeproj/project.pbxproj
+++ b/Demo/SVPullToRefreshDemo.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		22E0D93E1545EE7600BB6BB5 /* SVPullToRefresh.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 22E0D93C1545EE7600BB6BB5 /* SVPullToRefresh.bundle */; };
 		22E0D9411545EE9000BB6BB5 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22E0D9401545EE9000BB6BB5 /* QuartzCore.framework */; };
 		22E0D94B1545F63300BB6BB5 /* README.textile in Resources */ = {isa = PBXBuildFile; fileRef = 22E0D94A1545F63300BB6BB5 /* README.textile */; };
+		9C3486C61547C1B100B3A12B /* RootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C3486C41547C1B100B3A12B /* RootViewController.m */; };
+		9C3486C71547C1B100B3A12B /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9C3486C51547C1B100B3A12B /* RootViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +42,9 @@
 		22E0D93C1545EE7600BB6BB5 /* SVPullToRefresh.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = SVPullToRefresh.bundle; sourceTree = "<group>"; };
 		22E0D9401545EE9000BB6BB5 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		22E0D94A1545F63300BB6BB5 /* README.textile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.textile; path = ../README.textile; sourceTree = "<group>"; };
+		9C3486C31547C1B100B3A12B /* RootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RootViewController.h; sourceTree = "<group>"; };
+		9C3486C41547C1B100B3A12B /* RootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RootViewController.m; sourceTree = "<group>"; };
+		9C3486C51547C1B100B3A12B /* RootViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RootViewController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +101,9 @@
 				22E0D92B1545EE5B00BB6BB5 /* SVViewController.m */,
 				22E0D92D1545EE5B00BB6BB5 /* SVViewController.xib */,
 				22E0D91F1545EE5B00BB6BB5 /* Supporting Files */,
+				9C3486C31547C1B100B3A12B /* RootViewController.h */,
+				9C3486C41547C1B100B3A12B /* RootViewController.m */,
+				9C3486C51547C1B100B3A12B /* RootViewController.xib */,
 			);
 			name = Demo;
 			path = SVPullToRefreshDemo;
@@ -179,6 +187,7 @@
 				22E0D92F1545EE5B00BB6BB5 /* SVViewController.xib in Resources */,
 				22E0D93E1545EE7600BB6BB5 /* SVPullToRefresh.bundle in Resources */,
 				22E0D94B1545F63300BB6BB5 /* README.textile in Resources */,
+				9C3486C71547C1B100B3A12B /* RootViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -193,6 +202,7 @@
 				22E0D9291545EE5B00BB6BB5 /* SVAppDelegate.m in Sources */,
 				22E0D92C1545EE5B00BB6BB5 /* SVViewController.m in Sources */,
 				22E0D93D1545EE7600BB6BB5 /* SVPullToRefresh.m in Sources */,
+				9C3486C61547C1B100B3A12B /* RootViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/SVPullToRefreshDemo/RootViewController.h
+++ b/Demo/SVPullToRefreshDemo/RootViewController.h
@@ -1,0 +1,14 @@
+//
+//  RootViewController.h
+//  SVPullToRefreshDemo
+//
+//  Created by Christopher Pickslay on 4/24/12.
+//  Copyright (c) 2012 Home. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface RootViewController : UIViewController
+- (IBAction)didTapLaunch:(id)sender;
+
+@end

--- a/Demo/SVPullToRefreshDemo/RootViewController.m
+++ b/Demo/SVPullToRefreshDemo/RootViewController.m
@@ -1,0 +1,50 @@
+//
+//  RootViewController.m
+//  SVPullToRefreshDemo
+//
+//  Created by Christopher Pickslay on 4/24/12.
+//  Copyright (c) 2012 Home. All rights reserved.
+//
+
+#import "RootViewController.h"
+#import "SVViewController.h"
+
+@interface RootViewController ()
+
+@end
+
+@implementation RootViewController
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view from its nib.
+}
+
+- (void)viewDidUnload
+{
+    [super viewDidUnload];
+    // Release any retained subviews of the main view.
+    // e.g. self.myOutlet = nil;
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+}
+
+- (IBAction)didTapLaunch:(id)sender {
+    SVViewController *viewController = [[SVViewController alloc] init];
+    [self.navigationController pushViewController:viewController animated:YES];
+}
+
+@end

--- a/Demo/SVPullToRefreshDemo/RootViewController.xib
+++ b/Demo/SVPullToRefreshDemo/RootViewController.xib
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1296</int>
+		<string key="IBDocument.SystemVersion">11D50b</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2182</string>
+		<string key="IBDocument.AppKitVersion">1138.32</string>
+		<string key="IBDocument.HIToolboxVersion">568.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">1181</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUIView</string>
+			<string>IBUIButton</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUIButton" id="701482920">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 142}, {280, 37}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<reference key="NSWindow"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<string key="IBUINormalTitle">Launch</string>
+						<object class="NSColor" key="IBUIHighlightedTitleColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+						</object>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+						</object>
+						<object class="NSColor" key="IBUINormalTitleShadowColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MC41AA</bytes>
+						</object>
+						<object class="IBUIFontDescription" key="IBUIFontDescription">
+							<int key="type">2</int>
+							<double key="pointSize">15</double>
+						</object>
+						<object class="NSFont" key="IBUIFont">
+							<string key="NSName">Helvetica-Bold</string>
+							<double key="NSSize">15</double>
+							<int key="NSfFlags">16</int>
+						</object>
+					</object>
+				</array>
+				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
+				<reference key="NSNextKeyView"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">didTapLaunch:</string>
+						<reference key="source" ref="701482920"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">6</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="701482920"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="701482920"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">RootViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">6</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">RootViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<object class="NSMutableDictionary" key="actions">
+						<string key="NS.key.0">didTapLaunch:</string>
+						<string key="NS.object.0">id</string>
+					</object>
+					<object class="NSMutableDictionary" key="actionInfosByName">
+						<string key="NS.key.0">didTapLaunch:</string>
+						<object class="IBActionInfo" key="NS.object.0">
+							<string key="name">didTapLaunch:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</object>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/RootViewController.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
+			<real value="1296" key="NS.object.0"/>
+		</object>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">1181</string>
+	</data>
+</archive>

--- a/Demo/SVPullToRefreshDemo/SVAppDelegate.h
+++ b/Demo/SVPullToRefreshDemo/SVAppDelegate.h
@@ -14,6 +14,6 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
-@property (strong, nonatomic) SVViewController *viewController;
+@property (strong, nonatomic) UIViewController *viewController;
 
 @end

--- a/Demo/SVPullToRefreshDemo/SVAppDelegate.m
+++ b/Demo/SVPullToRefreshDemo/SVAppDelegate.m
@@ -8,7 +8,7 @@
 
 #import "SVAppDelegate.h"
 
-#import "SVViewController.h"
+#import "RootViewController.h"
 
 @implementation SVAppDelegate
 
@@ -17,9 +17,9 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    self.viewController = [[UINavigationController alloc] initWithRootViewController:[[RootViewController alloc] init]];
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
-    self.viewController = [[SVViewController alloc] initWithNibName:@"SVViewController" bundle:nil];
     self.window.rootViewController = self.viewController;
     [self.window makeKeyAndVisible];
     return YES;

--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -20,13 +20,16 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    __block SVPullToRefresh *ptr = tableView.pullToRefreshView;
-    [self.tableView addPullToRefreshWithActionHandler:^{
-        NSLog(@"refresh dataSource");
-        [ptr performSelector:@selector(stopAnimating) withObject:nil afterDelay:5];
-    }];
-    
+    [self.tableView addPullToRefreshWithTarget:self action:@selector(loadData)];    
     // that's it!
+}
+
+- (void)loadData {
+    [self performSelector:@selector(doneLoading) withObject:nil afterDelay:5];
+}
+
+- (void)doneLoading {
+    [tableView.pullToRefreshView stopAnimating];
 }
 
 #pragma mark -

--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -20,9 +20,10 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    __block SVPullToRefresh *ptr = tableView.pullToRefreshView;
     [self.tableView addPullToRefreshWithActionHandler:^{
         NSLog(@"refresh dataSource");
-        [tableView.pullToRefreshView performSelector:@selector(stopAnimating) withObject:nil afterDelay:2];
+        [ptr performSelector:@selector(stopAnimating) withObject:nil afterDelay:5];
     }];
     
     // that's it!

--- a/SVPullToRefresh/SVPullToRefresh.h
+++ b/SVPullToRefresh/SVPullToRefresh.h
@@ -25,6 +25,7 @@
 @interface UIScrollView (SVPullToRefresh)
 
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler;
+- (void)addPullToRefreshWithTarget:(id)target action:(SEL)selector;
 
 @property (nonatomic, strong) SVPullToRefresh *pullToRefreshView;
 

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -35,7 +35,7 @@ typedef NSUInteger SVPullToRefreshState;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
 @property (nonatomic, strong) UILabel *titleLabel;
 
-@property (nonatomic, strong) UIScrollView *scrollView;
+@property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, readwrite) UIEdgeInsets originalScrollViewContentInset;
 
 @end
@@ -227,7 +227,7 @@ static char UIScrollViewPullToRefreshView;
     [self willChangeValueForKey:@"pullToRefreshView"];
     objc_setAssociatedObject(self, &UIScrollViewPullToRefreshView,
                              pullToRefreshView,
-                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                             OBJC_ASSOCIATION_ASSIGN);
     [self didChangeValueForKey:@"pullToRefreshView"];
 }
 

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -9,6 +9,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 #import "SVPullToRefresh.h"
+#import <objc/message.h>
 
 enum {
     SVPullToRefreshStateHidden = 1,
@@ -28,6 +29,8 @@ typedef NSUInteger SVPullToRefreshState;
 - (void)scrollViewDidScroll:(CGPoint)contentOffset;
 
 @property (nonatomic, copy) void (^actionHandler)(void);
+@property (nonatomic, weak) id target;
+@property (nonatomic, assign) SEL selector;
 @property (nonatomic, readwrite) SVPullToRefreshState state;
 
 @property (nonatomic, strong) UIImageView *arrow;
@@ -45,6 +48,7 @@ typedef NSUInteger SVPullToRefreshState;
 
 // public properties
 @synthesize actionHandler, arrowColor, textColor, activityIndicatorViewStyle;
+@synthesize target, selector;
 
 @synthesize state;
 @synthesize scrollView = _scrollView;
@@ -192,6 +196,7 @@ typedef NSUInteger SVPullToRefreshState;
             [self.activityIndicatorView startAnimating];
             [self setScrollViewContentInset:UIEdgeInsetsMake(self.frame.origin.y*-1+self.originalScrollViewContentInset.top, 0, 0, 0)];
             [self rotateArrow:0 hide:YES];
+            objc_msgSend(self.target, self.selector, nil);
             if(actionHandler)
                 actionHandler();
             break;
@@ -220,6 +225,13 @@ static char UIScrollViewPullToRefreshView;
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler {
     SVPullToRefresh *pullToRefreshView = [[SVPullToRefresh alloc] initWithScrollView:self];
     pullToRefreshView.actionHandler = actionHandler;
+    self.pullToRefreshView = pullToRefreshView;
+}
+
+- (void)addPullToRefreshWithTarget:(id)target action:(SEL)selector {
+    SVPullToRefresh *pullToRefreshView = [[SVPullToRefresh alloc] initWithScrollView:self];
+    pullToRefreshView.target = target;
+    pullToRefreshView.selector = selector;
     self.pullToRefreshView = pullToRefreshView;
 }
 


### PR DESCRIPTION
Sam, nice work on this. One problem, which I've found in nearly all PTR implementations, is that you have a retain cycle. I updated the demo code to reference the SVPullToRefresh in a __block variable. Otherwise the controller gets retained when the block is copied, and it will never be released.

I also made the scrollView property weak instead of strong. The scroll view retains SVPullToRefresh in its subviews array. If SVPullToRefresh also retains the scrollView, neither will ever be released.

The problem is easy to reproduce in the Allocations instrument. Just tap the launch button, navigate back up, rinse, repeat. You'll see new instances SVController, SVPullToRefresh, and UITableView every time you launch the controller, which are never deallocated.
