### PR TITLE
Added new 'initial loading' feature and fixed bug.

### DIFF
--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -23,7 +23,7 @@
     [self.tableView addPullToRefreshWithActionHandler:^{
         NSLog(@"refresh dataSource");
         [tableView.pullToRefreshView performSelector:@selector(stopAnimating) withObject:nil afterDelay:2];
-    }];
+    } showAtInitialLoading:YES]; // shows the pulltorefreshview and calls the actionhandler when first called
     
     // that's it!
 }

--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -21,8 +21,8 @@
     [super viewDidLoad];
     
     [self.tableView addPullToRefreshWithActionHandler:^{
-        NSLog(@"refresh dataSource");
-        [tableView.pullToRefreshView performSelector:@selector(stopAnimating) withObject:nil afterDelay:2];
+            NSLog(@"refresh dataSource");
+            [tableView.pullToRefreshView performSelector:@selector(stopAnimating) withObject:nil afterDelay:2]; 
     } showAtInitialLoading:YES]; // shows the pulltorefreshview and calls the actionhandler when first called
     
     // that's it!

--- a/SVPullToRefresh/SVPullToRefresh.h
+++ b/SVPullToRefresh/SVPullToRefresh.h
@@ -10,6 +10,9 @@
 #import <UIKit/UIKit.h>
 
 @interface SVPullToRefresh : UIView
+{
+    BOOL loading;
+}
 
 @property (nonatomic, strong) UIColor *arrowColor;
 @property (nonatomic, strong) UIColor *textColor;
@@ -25,7 +28,7 @@
 
 @interface UIScrollView (SVPullToRefresh)
 
-- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler;
+- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler showAtInitialLoading:(BOOL)showAtInitialLoading;
 
 @property (nonatomic, strong) SVPullToRefresh *pullToRefreshView;
 

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -23,7 +23,7 @@ typedef NSUInteger SVPullToRefreshState;
 
 @interface SVPullToRefresh () 
 
-- (id)initWithScrollView:(UIScrollView*)scrollView actionHandler:(void (^)(void))aH showAtInitialLoading:(BOOL)showAtInitialLoading;
+- (id)initWithScrollView:(UIScrollView*)scrollView;
 - (void)rotateArrow:(float)degrees hide:(BOOL)hide;
 - (void)setScrollViewContentInset:(UIEdgeInsets)contentInset;
 - (void)scrollViewDidScroll:(CGPoint)contentOffset;


### PR DESCRIPTION
Added a new feature. If this feature is enabled, the pullToRefresh view will be shown immediately after it is added to a scrollview and will call the actionhandler as well. It's similar to the behavior of the pullToRefresh view in the Dutch Nu.nl app: when the app is launched first, the pullToRefresh view is shown and hides after the data is loaded. A screenshot from the Nu.nl app after launching it: http://whirlingcode.com/NUnlApp.PNG

The new feature can be enabled by calling  addPullToRefreshViewWithActionHandler:(void (^)(void))actionHandler showAtInitialLoading:YES. If 'NO' is passed to the showAtInitialLoading parameter, the pullToRefresh view won't be showed right after it's added to a scrollview and data will only be called when the pullToRefresh view is triggered.

Also, I fixed a bug that caused the pullToRefresh view to change state if the user scrolled the pullToRefresh view while it was in loading state. 
