### PR TITLE
Copy actionHandler blocks in block setter methods.

### DIFF
--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -173,7 +173,7 @@ typedef NSUInteger SVPullToRefreshState;
 #pragma mark - Setters
 
 - (void)setPullToRefreshActionHandler:(void (^)(void))actionHandler {
-    pullToRefreshActionHandler = actionHandler;
+    pullToRefreshActionHandler = Block_copy(actionHandler);
     [_scrollView addSubview:self];
     self.showsPullToRefresh = YES;
     
@@ -191,7 +191,7 @@ typedef NSUInteger SVPullToRefreshState;
 }
 
 - (void)setInfiniteScrollingActionHandler:(void (^)(void))actionHandler {
-    infiniteScrollingActionHandler = actionHandler;
+    infiniteScrollingActionHandler = Block_copy(actionHandler);
     self.showsInfiniteScrolling = YES;
     
     self.frame = CGRectMake(0, 0, self.scrollView.bounds.size.width, 60);


### PR DESCRIPTION
The overridden setter methods for the refresh and infinite scrolling
handler blocks were retaining the blocks instead of copying them.
This causes a subtle crash when the handler blocks are accessed.
