### PR TITLE
Only observe scrollview while pullToRefreshView is a subview.

### DIFF
--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -21,9 +21,6 @@ typedef NSUInteger SVPullToRefreshState;
 
 
 @interface SVPullToRefresh ()
-{
-    BOOL    _observingScrollView;
-}
 
 - (id)initWithScrollView:(UIScrollView*)scrollView;
 - (void)rotateArrow:(float)degrees hide:(BOOL)hide;
@@ -47,6 +44,7 @@ typedef NSUInteger SVPullToRefreshState;
 
 @property (nonatomic, assign) BOOL showsPullToRefresh;
 @property (nonatomic, assign) BOOL showsInfiniteScrolling;
+@property (nonatomic, assign) BOOL observingScrollView;
 
 @end
 
@@ -59,7 +57,7 @@ typedef NSUInteger SVPullToRefreshState;
 
 @synthesize state;
 @synthesize scrollView = _scrollView;
-@synthesize arrow, arrowImage, activityIndicatorView, titleLabel, dateLabel, originalScrollViewContentInset, originalTableFooterView, showsPullToRefresh, showsInfiniteScrolling;
+@synthesize arrow, arrowImage, activityIndicatorView, titleLabel, dateLabel, originalScrollViewContentInset, originalTableFooterView, showsPullToRefresh, showsInfiniteScrolling, observingScrollView;
 
 - (void)dealloc {
     [self stopObservingScrollView];
@@ -258,22 +256,22 @@ typedef NSUInteger SVPullToRefreshState;
 
 - (void)startObservingScrollView
 {
-    if ( _observingScrollView )
+    if ( self.observingScrollView )
         return;
     
     [self.scrollView addObserver:self forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
     [self.scrollView addObserver:self forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:nil];
-    _observingScrollView = YES;
+    self.observingScrollView = YES;
 }
 
 - (void)stopObservingScrollView
 {
-    if ( !_observingScrollView )
+    if ( self.observingScrollView )
         return;
     
     [self.scrollView removeObserver:self forKeyPath:@"contentOffset"];
     [self.scrollView removeObserver:self forKeyPath:@"frame"];
-    _observingScrollView = NO;
+    self.observingScrollView = NO;
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {


### PR DESCRIPTION
KVO for scrollview properties was previously started in -init and removed in -dealloc.
However, the timing of dealloc is not determinant, since it may be called on another
thread.  In cases where both the pullToRefresh and infiniteScrollingView are
present, it is possible to reach a condition where the scrollview (e.g. tableview)
is deallocated before KVO properties are removed. Since the
pullToRefresh views are stored in associated objects on the scrollview, it is also
not clear exactly when the associated objects will be released.
By implementing -[UIView willMoveToSuperview:] and managing KVO properties there, we ensure
that KVO is directly coupled to state of the scrollview's hierarchy. Note that we
still include a call to -stopObservingScrollview in -dealloc.  This guards against
cases where UIView notifications may not be sent and is otherwise a no-op.
