### PR TITLE
Fix early-exit condition in -stopObservingScrollView

### DIFF
--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -265,7 +265,7 @@ typedef NSUInteger SVPullToRefreshState;
 }
 
 - (void)stopObservingScrollView {
-    if(self.isObservingScrollView)
+    if(!self.isObservingScrollView)
         return;
     
     [self.scrollView removeObserver:self forKeyPath:@"contentOffset"];


### PR DESCRIPTION
This bug was introduced when converting the boolean flag from an ivar
to a property.

See comment by @jparise:
https://github.com/chapados/SVPullToRefresh/commit/8e1799b2b21cda0881f7d6636ca7b4be504cd8b4#commitcomment-1477891
