### PR TITLE
Fixed a bug where the original footer was not properly saved

### DIFF
--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -187,13 +187,11 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 }
 
 - (void)setInfiniteScrollingActionHandler:(void (^)(void))actionHandler {
+    self.originalTableFooterView = [(UITableView*)self.scrollView tableFooterView];
     infiniteScrollingActionHandler = [actionHandler copy];
     self.showsInfiniteScrolling = YES;
-    
     self.frame = CGRectMake(0, 0, self.scrollView.bounds.size.width, SVPullToRefreshViewHeight);
-    self.originalTableFooterView = [(UITableView*)self.scrollView tableFooterView];
     [(UITableView*)self.scrollView setTableFooterView:self];
-    
     self.state = SVPullToRefreshStateHidden;    
     [self layoutSubviews];
 }


### PR DESCRIPTION
The original footer was clobbered before it was saved in the `setInfiniteScrollingActionHandler:` method. I've updated the method to properly save the footer view before adjusting it.
