### PR TITLE
Expose SVPullToRefreshState as readonly

### DIFF
--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -22,6 +22,8 @@
     // setup the pull-to-refresh view
     [self.tableView addPullToRefreshWithActionHandler:^{
         NSLog(@"refresh dataSource");
+        if (tableView.pullToRefreshView.state == SVPullToRefreshStateLoading)
+            NSLog(@"Pull to refresh is loading");
         [tableView.pullToRefreshView performSelector:@selector(stopAnimating) withObject:nil afterDelay:2];
     }];
     
@@ -29,6 +31,9 @@
         NSLog(@"load more data");
     }];
     
+    if (tableView.pullToRefreshView.state == SVPullToRefreshStateHidden)
+        NSLog(@"Pull to refresh is hidden");
+
     // trigger the refresh manually at the end of viewDidLoad
     [tableView.pullToRefreshView triggerRefresh];
     

--- a/SVPullToRefresh/SVPullToRefresh.h
+++ b/SVPullToRefresh/SVPullToRefresh.h
@@ -9,6 +9,15 @@
 
 #import <UIKit/UIKit.h>
 
+enum {
+    SVPullToRefreshStateHidden = 1,
+	SVPullToRefreshStateVisible,
+    SVPullToRefreshStateTriggered,
+    SVPullToRefreshStateLoading
+};
+
+typedef NSUInteger SVPullToRefreshState;
+
 @interface SVPullToRefresh : UIView
 
 @property (nonatomic, strong) UIColor *arrowColor;
@@ -18,6 +27,8 @@
 @property (nonatomic, strong) UILabel *dateLabel;
 @property (nonatomic, strong) NSDate *lastUpdatedDate;
 @property (nonatomic, strong) NSDateFormatter *dateFormatter;
+
+@property (nonatomic, readonly) SVPullToRefreshState state;
 
 - (void)triggerRefresh;
 - (void)startAnimating;

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -10,15 +10,6 @@
 #import <QuartzCore/QuartzCore.h>
 #import "SVPullToRefresh.h"
 
-enum {
-    SVPullToRefreshStateHidden = 1,
-	SVPullToRefreshStateVisible,
-    SVPullToRefreshStateTriggered,
-    SVPullToRefreshStateLoading
-};
-
-typedef NSUInteger SVPullToRefreshState;
-
 static CGFloat const SVPullToRefreshViewHeight = 60;
 
 @interface SVPullToRefreshArrow : UIView
@@ -38,7 +29,6 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 
 @property (nonatomic, copy) void (^pullToRefreshActionHandler)(void);
 @property (nonatomic, copy) void (^infiniteScrollingActionHandler)(void);
-@property (nonatomic, readwrite) SVPullToRefreshState state;
 
 @property (nonatomic, strong) SVPullToRefreshArrow *arrow;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
@@ -62,7 +52,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 // public properties
 @synthesize pullToRefreshActionHandler, infiniteScrollingActionHandler, arrowColor, textColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter;
 
-@synthesize state;
+@synthesize state = _state;
 @synthesize scrollView = _scrollView;
 @synthesize arrow, activityIndicatorView, titleLabel, dateLabel, originalScrollViewContentInset, originalTableFooterView, showsPullToRefresh, showsInfiniteScrolling, isObservingScrollView;
 
@@ -304,7 +294,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 }
 
 - (void)startAnimating{
-    state = SVPullToRefreshStateLoading;
+    _state = SVPullToRefreshStateLoading;
     
     titleLabel.text = NSLocalizedString(@"Loading...",);
     [self.activityIndicatorView startAnimating];
@@ -333,10 +323,10 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
     if(infiniteScrollingActionHandler && !self.showsInfiniteScrolling)
         return;   
     
-    if(state == newState)
+    if(_state == newState)
         return;
     
-    state = newState;
+    _state = newState;
     
     if(pullToRefreshActionHandler) {
         switch (newState) {


### PR DESCRIPTION
This is helpful when the callback is also used in other parts of the controller

E.g.

``` obj-c
// For demo purposes: this should be __weak in ARC
__block typeof(self) bself = self;
  [self.tableView addPullToRefreshWithActionHandler:^{
  [bself fetchPosts]; 
}];

// ...

- (void)fetchPosts
{
  if (self.tableView.pullToRefreshView.state == SVPullToRefreshStateLoading) NSLog("foo");
}
```
