### PR TITLE
Customizing messages for refresh states

### DIFF
--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -19,6 +19,10 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    NSDictionary *messages = [NSDictionary dictionaryWithObjectsAndKeys:
+                              @"Downloading...", STRINGIFY(SVPullToRefreshStateLoading), nil];
+    [self.tableView.pullToRefreshView setStateMessages:messages];
+    
     // setup the pull-to-refresh view
     [self.tableView addPullToRefreshWithActionHandler:^{
         NSLog(@"refresh dataSource");

--- a/SVPullToRefresh/SVPullToRefresh.h
+++ b/SVPullToRefresh/SVPullToRefresh.h
@@ -9,6 +9,8 @@
 
 #import <UIKit/UIKit.h>
 
+#define STRINGIFY(SVPullToRefreshState) [[NSNumber numberWithInt:SVPullToRefreshState] stringValue]
+
 enum {
     SVPullToRefreshStateHidden = 1,
 	SVPullToRefreshStateVisible,
@@ -23,6 +25,7 @@ typedef NSUInteger SVPullToRefreshState;
 @property (nonatomic, strong) UIColor *arrowColor;
 @property (nonatomic, strong) UIColor *textColor;
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
+@property (nonatomic, strong) NSDictionary *stateMessages;
 
 @property (nonatomic, strong) UILabel *dateLabel;
 @property (nonatomic, strong) NSDate *lastUpdatedDate;

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -53,6 +53,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 @synthesize pullToRefreshActionHandler, infiniteScrollingActionHandler, arrowColor, textColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter;
 
 @synthesize state = _state;
+@synthesize stateMessages;
 @synthesize scrollView = _scrollView;
 @synthesize arrow, activityIndicatorView, titleLabel, dateLabel, originalScrollViewContentInset, originalTableFooterView, showsPullToRefresh, showsInfiniteScrolling, isObservingScrollView;
 
@@ -296,7 +297,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 - (void)startAnimating{
     _state = SVPullToRefreshStateLoading;
     
-    titleLabel.text = NSLocalizedString(@"Loading...",);
+    titleLabel.text = [self messageForState:SVPullToRefreshStateLoading placeholder:NSLocalizedString(@"Loading...",)];
     [self.activityIndicatorView startAnimating];
     UIEdgeInsets newInsets = self.originalScrollViewContentInset;
     newInsets.top = self.frame.origin.y*-1+self.originalScrollViewContentInset.top;
@@ -329,16 +330,17 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
     _state = newState;
     
     if(pullToRefreshActionHandler) {
+        NSString *messagePlaceholder = nil;
         switch (newState) {
             case SVPullToRefreshStateHidden:
-                titleLabel.text = NSLocalizedString(@"Pull to refresh...",);
+                messagePlaceholder = NSLocalizedString(@"Pull to refresh...",);
                 [self.activityIndicatorView stopAnimating];
                 [self setScrollViewContentInset:self.originalScrollViewContentInset];
                 [self rotateArrow:0 hide:NO];
                 break;
                 
             case SVPullToRefreshStateVisible:
-                titleLabel.text = NSLocalizedString(@"Pull to refresh...",);
+                messagePlaceholder = NSLocalizedString(@"Pull to refresh...",);
                 arrow.alpha = 1;
                 [self.activityIndicatorView stopAnimating];
                 [self setScrollViewContentInset:self.originalScrollViewContentInset];
@@ -346,7 +348,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
                 break;
                 
             case SVPullToRefreshStateTriggered:
-                titleLabel.text = NSLocalizedString(@"Release to refresh...",);
+                messagePlaceholder = NSLocalizedString(@"Release to refresh...",);
                 [self rotateArrow:M_PI hide:NO];
                 break;
                 
@@ -355,6 +357,8 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
                 pullToRefreshActionHandler();
                 break;
         }
+        if (messagePlaceholder)
+            titleLabel.text = [self messageForState:newState placeholder:messagePlaceholder];
     }
     else if(infiniteScrollingActionHandler) {
         switch (newState) {
@@ -368,6 +372,15 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
                 break;
         }
     }
+}
+
+- (NSString *)messageForState:(SVPullToRefreshState)state placeholder:(NSString *)placeholder
+{
+    NSString *message = nil;
+    NSString *key = STRINGIFY(state);
+    message = [stateMessages valueForKey:key];
+
+    return message == nil ? placeholder : message;
 }
 
 - (void)rotateArrow:(float)degrees hide:(BOOL)hide {


### PR DESCRIPTION
A way to customize status messages
- Implements a NSDictionary using SVPullToRefreshStates as keys
- Fallbacks to hardcoded placeholders

``` obj-c
NSDictionary *messages = [NSDictionary dictionaryWithObjectsAndKeys:@"Downloading...", STRINGIFY(SVPullToRefreshStateLoading), nil];
[self.tableView.pullToRefreshView setStateMessages:messages];
```

Depends on pull request #58 (i.e. public SVPullToRefreshState)
