### PR TITLE
Don't remove associated views on move to nil superview.

### DIFF
--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -394,16 +394,6 @@ static char UIScrollViewInfiniteScrollingView;
 
 @dynamic pullToRefreshView, showsPullToRefresh, infiniteScrollingView, showsInfiniteScrolling;
 
-- (void)willMoveToSuperview:(UIView *)newSuperview {
-    if(!newSuperview) {
-        [self.pullToRefreshView removeFromSuperview];
-        self.pullToRefreshView = nil;
-        
-        [self.infiniteScrollingView removeFromSuperview];
-        self.infiniteScrollingView = nil;
-    }
-}
-
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler {
     self.pullToRefreshView.pullToRefreshActionHandler = actionHandler;
 }

--- a/SVPullToRefresh/SVPullToRefresh.m
+++ b/SVPullToRefresh/SVPullToRefresh.m
@@ -162,13 +162,16 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
     [_scrollView addSubview:self];
     self.showsPullToRefresh = YES;
     
-    self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, 150, 20)];
-    titleLabel.text = NSLocalizedString(@"Pull to refresh...",);
-    titleLabel.font = [UIFont boldSystemFontOfSize:14];
-    titleLabel.backgroundColor = [UIColor clearColor];
-    titleLabel.textColor = textColor;
-    [self addSubview:titleLabel];
-    
+    // If the titleLabel is added before, there is no need to add again.
+    if (self.titleLabel == nil) {
+        self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, 150, 20)];
+        titleLabel.text = NSLocalizedString(@"Pull to refresh...",);
+        titleLabel.font = [UIFont boldSystemFontOfSize:14];
+        titleLabel.backgroundColor = [UIColor clearColor];
+        titleLabel.textColor = textColor;
+        [self addSubview:titleLabel];
+    }
+
     [self addSubview:self.arrow];
     	
     self.state = SVPullToRefreshStateHidden;    


### PR DESCRIPTION
While this code was likely originally added in order to prevent a leak, the transition to associated the views via OBJC_ASSOCIATION_RETAIN rather than OBJC_ASSOCIATION_ASSIGN means that the associated view objects will be released when the owning object (the UIScrollView instance) is de-alloc'd.

Fixes #63. Fixes #62.
