### PR TITLE
fix bug with "retain cycle" memory issues and remove KVO observer

### DIFF
--- a/Demo/SVPullToRefreshDemo.xcodeproj/project.pbxproj
+++ b/Demo/SVPullToRefreshDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		22E0D94B1545F63300BB6BB5 /* README.textile in Resources */ = {isa = PBXBuildFile; fileRef = 22E0D94A1545F63300BB6BB5 /* README.textile */; };
 		22FDEC971639082E00DB53A8 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 22FDEC961639082E00DB53A8 /* Default-568h@2x.png */; };
 		22FDEC9D16390CC800DB53A8 /* UIScrollView+SVInfiniteScrolling.m in Sources */ = {isa = PBXBuildFile; fileRef = 2288146016047C06005C6461 /* UIScrollView+SVInfiniteScrolling.m */; };
+		8E7FDB661640EBA200EE63E5 /* SVRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E7FDB641640EBA200EE63E5 /* SVRootViewController.m */; };
+		8E7FDB671640EBA200EE63E5 /* SVRootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8E7FDB651640EBA200EE63E5 /* SVRootViewController.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +46,9 @@
 		22E0D9401545EE9000BB6BB5 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		22E0D94A1545F63300BB6BB5 /* README.textile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.textile; path = ../README.textile; sourceTree = "<group>"; };
 		22FDEC961639082E00DB53A8 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
+		8E7FDB631640EBA200EE63E5 /* SVRootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVRootViewController.h; sourceTree = "<group>"; };
+		8E7FDB641640EBA200EE63E5 /* SVRootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVRootViewController.m; sourceTree = "<group>"; };
+		8E7FDB651640EBA200EE63E5 /* SVRootViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SVRootViewController.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +101,9 @@
 			children = (
 				22E0D9271545EE5B00BB6BB5 /* SVAppDelegate.h */,
 				22E0D9281545EE5B00BB6BB5 /* SVAppDelegate.m */,
+				8E7FDB631640EBA200EE63E5 /* SVRootViewController.h */,
+				8E7FDB641640EBA200EE63E5 /* SVRootViewController.m */,
+				8E7FDB651640EBA200EE63E5 /* SVRootViewController.xib */,
 				22E0D92A1545EE5B00BB6BB5 /* SVViewController.h */,
 				22E0D92B1545EE5B00BB6BB5 /* SVViewController.m */,
 				22E0D92D1545EE5B00BB6BB5 /* SVViewController.xib */,
@@ -186,6 +194,7 @@
 				22E0D92F1545EE5B00BB6BB5 /* SVViewController.xib in Resources */,
 				22E0D94B1545F63300BB6BB5 /* README.textile in Resources */,
 				22FDEC971639082E00DB53A8 /* Default-568h@2x.png in Resources */,
+				8E7FDB671640EBA200EE63E5 /* SVRootViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -201,6 +210,7 @@
 				22E0D92C1545EE5B00BB6BB5 /* SVViewController.m in Sources */,
 				22E0D93D1545EE7600BB6BB5 /* UIScrollView+SVPullToRefresh.m in Sources */,
 				22FDEC9D16390CC800DB53A8 /* UIScrollView+SVInfiniteScrolling.m in Sources */,
+				8E7FDB661640EBA200EE63E5 /* SVRootViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/SVPullToRefreshDemo/SVAppDelegate.h
+++ b/Demo/SVPullToRefreshDemo/SVAppDelegate.h
@@ -14,6 +14,4 @@
 
 @property (strong, nonatomic) UIWindow *window;
 
-@property (strong, nonatomic) SVViewController *viewController;
-
 @end

--- a/Demo/SVPullToRefreshDemo/SVAppDelegate.m
+++ b/Demo/SVPullToRefreshDemo/SVAppDelegate.m
@@ -8,19 +8,17 @@
 
 #import "SVAppDelegate.h"
 
-#import "SVViewController.h"
+#import "SVRootViewController.h"
 
 @implementation SVAppDelegate
 
 @synthesize window = _window;
-@synthesize viewController = _viewController;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
-    self.viewController = [[SVViewController alloc] initWithNibName:@"SVViewController" bundle:nil];
-    self.window.rootViewController = self.viewController;
+    self.window.rootViewController = [[UINavigationController alloc] initWithRootViewController:[[SVRootViewController alloc] initWithNibName:@"SVRootViewController" bundle:nil]];
     [self.window makeKeyAndVisible];
     return YES;
 }

--- a/Demo/SVPullToRefreshDemo/SVPullToRefreshDemo-Prefix.pch
+++ b/Demo/SVPullToRefreshDemo/SVPullToRefreshDemo-Prefix.pch
@@ -12,3 +12,7 @@
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
 #endif
+
+#ifdef DEBUG
+#define SV_DEBUG_MEMORY_LEAK
+#endif

--- a/Demo/SVPullToRefreshDemo/SVRootViewController.h
+++ b/Demo/SVPullToRefreshDemo/SVRootViewController.h
@@ -1,0 +1,15 @@
+//
+//  SVRootViewController.h
+//  SVPullToRefreshDemo
+//
+//  Created by fengjian on 12-10-31.
+//  Copyright (c) 2012年 Home. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SVRootViewController : UIViewController
+
+- (IBAction)showTableView:(id)sender;
+
+@end

--- a/Demo/SVPullToRefreshDemo/SVRootViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVRootViewController.m
@@ -1,0 +1,43 @@
+//
+//  SVRootViewController.m
+//  SVPullToRefreshDemo
+//
+//  Created by fengjian on 12-10-31.
+//  Copyright (c) 2012年 Home. All rights reserved.
+//
+
+#import "SVRootViewController.h"
+#import "SVViewController.h"
+
+@interface SVRootViewController ()
+
+@end
+
+@implementation SVRootViewController
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    // Do any additional setup after loading the view from its nib.
+}
+
+- (void)didReceiveMemoryWarning
+{
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (IBAction)showTableView:(id)sender
+{
+    [self.navigationController pushViewController:[[SVViewController alloc] initWithNibName:@"SVViewController" bundle:nil] animated:YES];
+}
+@end

--- a/Demo/SVPullToRefreshDemo/SVRootViewController.xib
+++ b/Demo/SVPullToRefreshDemo/SVRootViewController.xib
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
+	<data>
+		<int key="IBDocument.SystemTarget">1536</int>
+		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2843</string>
+		<string key="IBDocument.AppKitVersion">1187.34</string>
+		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
+			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			<string key="NS.object.0">1929</string>
+		</object>
+		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBProxyObject</string>
+			<string>IBUIButton</string>
+			<string>IBUIView</string>
+		</array>
+		<array key="IBDocument.PluginDependencies">
+			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+		</array>
+		<object class="NSMutableDictionary" key="IBDocument.Metadata">
+			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
+			<integer value="1" key="NS.object.0"/>
+		</object>
+		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
+			<object class="IBProxyObject" id="372490531">
+				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBProxyObject" id="975951072">
+				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+			<object class="IBUIView" id="191373211">
+				<reference key="NSNextResponder"/>
+				<int key="NSvFlags">274</int>
+				<array class="NSMutableArray" key="NSSubviews">
+					<object class="IBUIButton" id="428280033">
+						<reference key="NSNextResponder" ref="191373211"/>
+						<int key="NSvFlags">301</int>
+						<string key="NSFrame">{{87, 252}, {146, 44}}</string>
+						<reference key="NSSuperview" ref="191373211"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<string key="IBUINormalTitle">Show Table View</string>
+						<object class="NSColor" key="IBUIHighlightedTitleColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+						</object>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+						</object>
+						<object class="NSColor" key="IBUINormalTitleShadowColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MC41AA</bytes>
+						</object>
+						<object class="IBUIFontDescription" key="IBUIFontDescription">
+							<int key="type">2</int>
+							<double key="pointSize">15</double>
+						</object>
+						<object class="NSFont" key="IBUIFont">
+							<string key="NSName">Helvetica-Bold</string>
+							<double key="NSSize">15</double>
+							<int key="NSfFlags">16</int>
+						</object>
+					</object>
+				</array>
+				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
+				<reference key="NSSuperview"/>
+				<reference key="NSNextKeyView" ref="428280033"/>
+				<object class="NSColor" key="IBUIBackgroundColor">
+					<int key="NSColorSpace">3</int>
+					<bytes key="NSWhite">MQA</bytes>
+					<object class="NSColorSpace" key="NSCustomColorSpace">
+						<int key="NSID">2</int>
+					</object>
+				</object>
+				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
+				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
+					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
+					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
+						<bool key="EncodedWithXMLCoder">YES</bool>
+						<array key="dict.sortedKeys">
+							<integer value="1"/>
+							<integer value="3"/>
+						</array>
+						<array key="dict.values">
+							<string>{320, 568}</string>
+							<string>{568, 320}</string>
+						</array>
+					</object>
+					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
+					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
+					<int key="IBUIType">2</int>
+				</object>
+				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+			</object>
+		</array>
+		<object class="IBObjectContainer" key="IBDocument.Objects">
+			<array class="NSMutableArray" key="connectionRecords">
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">view</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="191373211"/>
+					</object>
+					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">showTableView:</string>
+						<reference key="source" ref="428280033"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">8</int>
+				</object>
+			</array>
+			<object class="IBMutableOrderedSet" key="objectRecords">
+				<array key="orderedObjects">
+					<object class="IBObjectRecord">
+						<int key="objectID">0</int>
+						<array key="object" id="0"/>
+						<reference key="children" ref="1000"/>
+						<nil key="parent"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">1</int>
+						<reference key="object" ref="191373211"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="428280033"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-1</int>
+						<reference key="object" ref="372490531"/>
+						<reference key="parent" ref="0"/>
+						<string key="objectName">File's Owner</string>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">-2</int>
+						<reference key="object" ref="975951072"/>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">4</int>
+						<reference key="object" ref="428280033"/>
+						<reference key="parent" ref="191373211"/>
+					</object>
+				</array>
+			</object>
+			<dictionary class="NSMutableDictionary" key="flattenedProperties">
+				<string key="-1.CustomClassName">SVRootViewController</string>
+				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="-2.CustomClassName">UIResponder</string>
+				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+			</dictionary>
+			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
+			<nil key="activeLocalization"/>
+			<dictionary class="NSMutableDictionary" key="localizations"/>
+			<nil key="sourceID"/>
+			<int key="maxID">8</int>
+		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<int key="IBDocument.localizationMode">0</int>
+		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
+		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
+		<int key="IBDocument.defaultPropertyAccessControl">3</int>
+		<string key="IBCocoaTouchPluginVersion">1929</string>
+	</data>
+</archive>

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -28,7 +28,7 @@ static CGFloat const SVInfiniteScrollingViewHeight = 60;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
 @property (nonatomic, readwrite) SVInfiniteScrollingState state;
 @property (nonatomic, strong) NSMutableArray *viewForState;
-@property (nonatomic, strong, readonly) UIScrollView *scrollView;
+@property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, readwrite) CGFloat originalBottomInset;
 @property (nonatomic, assign) BOOL wasTriggeredByUser;
 
@@ -55,6 +55,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     if(!self.infiniteScrollingView) {
         SVInfiniteScrollingView *view = [[SVInfiniteScrollingView alloc] initWithFrame:CGRectMake(0, self.contentSize.height, self.bounds.size.width, SVInfiniteScrollingViewHeight)];
         view.infiniteScrollingHandler = actionHandler;
+        view.scrollView = self;
         [self addSubview:view];
         
         view.originalBottomInset = self.contentInset.bottom;
@@ -127,6 +128,14 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     return self;
 }
 
+#ifdef SV_DEBUG_MEMORY_LEAK
+- (void)dealloc
+{
+    //If this func not being called, there must be something wrong, e.g retain cycle
+    NSLog(@"%s, %s", __FILE__, __FUNCTION__);
+}
+#endif
+
 - (void)layoutSubviews {
     self.activityIndicatorView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
 }
@@ -189,15 +198,6 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         [self addSubview:_activityIndicatorView];
     }
     return _activityIndicatorView;
-}
-
-- (UIScrollView *)scrollView {
-    _scrollView = (UIScrollView*)self.superview;
-    
-    while(![_scrollView isKindOfClass:[UIScrollView class]])
-        _scrollView = (UIScrollView*)_scrollView.superview;
-    
-    return _scrollView;
 }
 
 - (UIActivityIndicatorViewStyle)activityIndicatorViewStyle {

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -139,8 +139,11 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
     if (self.superview && newSuperview == nil) {
-        [self.superview removeObserver:self forKeyPath:@"contentOffset"];
-        [self.superview removeObserver:self forKeyPath:@"contentSize"];
+        UIScrollView *scrollView = (UIScrollView *)self.superview;
+        if (scrollView.showsInfiniteScrolling) {
+            [scrollView removeObserver:self forKeyPath:@"contentOffset"];
+            [scrollView removeObserver:self forKeyPath:@"contentSize"];
+        }
     }
 }
 

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -136,6 +136,14 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 }
 #endif
 
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{
+    if (self.superview && newSuperview == nil) {
+        [self.superview removeObserver:self forKeyPath:@"contentOffset"];
+        [self.superview removeObserver:self forKeyPath:@"contentSize"];
+    }
+}
+
 - (void)layoutSubviews {
     self.activityIndicatorView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
 }

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -34,7 +34,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 @property (nonatomic, strong) NSMutableArray *subtitles;
 @property (nonatomic, strong) NSMutableArray *viewForState;
 
-@property (nonatomic, strong, readonly) UIScrollView *scrollView;
+@property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, readwrite) CGFloat originalTopInset;
 
 @property (nonatomic, assign) BOOL wasTriggeredByUser;
@@ -64,6 +64,7 @@ static char UIScrollViewPullToRefreshView;
     if(!self.pullToRefreshView) {
         SVPullToRefreshView *view = [[SVPullToRefreshView alloc] initWithFrame:CGRectMake(0, -SVPullToRefreshViewHeight, self.bounds.size.width, SVPullToRefreshViewHeight)];
         view.pullToRefreshActionHandler = actionHandler;
+        view.scrollView = self;
         [self addSubview:view];
         
         view.originalTopInset = self.contentInset.top;
@@ -146,6 +147,14 @@ static char UIScrollViewPullToRefreshView;
 
     return self;
 }
+
+#ifdef SV_DEBUG_MEMORY_LEAK
+- (void)dealloc
+{
+    //If this func not being called, there must be something wrong, e.g retain cycle
+    NSLog(@"%s, %s", __FILE__, __FUNCTION__);
+}
+#endif
 
 - (void)layoutSubviews {
     CGFloat remainingWidth = self.superview.bounds.size.width-200;
@@ -305,15 +314,6 @@ static char UIScrollViewPullToRefreshView;
 
 - (UILabel *)dateLabel {
     return self.subtitleLabel;
-}
-
-- (UIScrollView *)scrollView {
-    _scrollView = (UIScrollView*)self.superview;
-    
-    while(![_scrollView isKindOfClass:[UIScrollView class]])
-        _scrollView = (UIScrollView*)_scrollView.superview;
-    
-    return _scrollView;
 }
 
 - (NSDateFormatter *)dateFormatter {

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -159,10 +159,13 @@ static char UIScrollViewPullToRefreshView;
 - (void)willMoveToSuperview:(UIView *)newSuperview
 { 
     if (self.superview && newSuperview == nil) {
-        //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
-        [self.superview removeObserver:self forKeyPath:@"contentOffset"];
-        [self.superview removeObserver:self forKeyPath:@"frame"];
         //use self.superview, not self.scrollView. Why self.scrollView == nil here?
+        UIScrollView *scrollView = (UIScrollView *)self.superview;
+        if (scrollView.showsPullToRefresh) {
+            //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
+            [scrollView removeObserver:self forKeyPath:@"contentOffset"];
+            [scrollView removeObserver:self forKeyPath:@"frame"];
+        }
     }
 }
 

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -156,6 +156,16 @@ static char UIScrollViewPullToRefreshView;
 }
 #endif
 
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{ 
+    if (self.superview && newSuperview == nil) {
+        //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
+        [self.superview removeObserver:self forKeyPath:@"contentOffset"];
+        [self.superview removeObserver:self forKeyPath:@"frame"];
+        //use self.superview, not self.scrollView. Why self.scrollView == nil here?
+    }
+}
+
 - (void)layoutSubviews {
     CGFloat remainingWidth = self.superview.bounds.size.width-200;
     float position = 0.50;


### PR DESCRIPTION
hi samvermette, I like SVPullToRefresh, the design of it's public api is very cool. But there is some memory issues both in SVPullToRefresh and the Demo. The bug is "retain cycle", I suggest reading http://stackoverflow.com/questions/7853915/how-do-i-avoid-capturing-self-in-blocks-when-implementing-an-api

And I try to fix the bug, description as follows
1 Add SVRootViewController and UINavigationController and three "- (void)dealloc" to show the retain cycle memory leak. And use __weak/weak to fix the bug. Also can use instruments to see the memory bug

2 In SVPullToRefresh, the UIScrollView has add a KVO observer, but when the UIScrollView dealloc, it doesn't remove the observer. Also, it seems that the UIScrollView has no way to remove the observer elegantly without change the public api. I fix the bug with some trick, maybe not elegant, but it does can work -- I remove the observer in the "willMoveToSuperview" func of SVPullToRefreshView. ##The same bug with SVInfiniteScrolling.

Wth the original bug, the console will show some warning info like below :
2012-10-31 14:07:41.668 SVPullToRefreshDemo[5007:c07] An instance 0x99aa400 of class UITableView was deallocated while key value observers were still registered with it. Observation info was leaked, and may even become mistakenly attached to some other object. Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger. Here's the current observation info:
<NSKeyValueObservationInfo 0x89248e0> (
<NSKeyValueObservance 0x8921e60: Observer: 0x891d0f0, Key path: contentOffset, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x8921a50>
<NSKeyValueObservance 0x8923610: Observer: 0x891d0f0, Key path: frame, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x89237a0>
<NSKeyValueObservance 0x8924820: Observer: 0x8923d50, Key path: contentOffset, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x8921a50>
<NSKeyValueObservance 0x89248a0: Observer: 0x8923d50, Key path: contentSize, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0, Property: 0x8924900>
)
