### PR TITLE
Fix subtitles not displaying issue

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -289,7 +289,7 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (UILabel *)subtitleLabel {
-    if(!_subtitleLabel && self.showsDateLabel) {
+    if(!_subtitleLabel) {
         _subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 28, 180, 20)];
         _subtitleLabel.font = [UIFont systemFontOfSize:12];
         _subtitleLabel.backgroundColor = [UIColor clearColor];
@@ -304,7 +304,7 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (UILabel *)dateLabel {
-    return self.subtitleLabel;
+    return self.showsDateLabel ? self.subtitleLabel : nil;
 }
 
 - (UIScrollView *)scrollView {


### PR DESCRIPTION
The only way to display a subtitle label was to set the deprecated `lastUpdatedDate` property. Calling `setSubtitle:forState:` now always display subtitles.
