### PR TITLE
Update title & subtitle label widths

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -301,7 +301,7 @@ static char UIScrollViewPullToRefreshView;
 
 - (UILabel *)titleLabel {
     if(!_titleLabel) {
-        _titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, 150, 20)];
+        _titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 20, 210, 20)];
         _titleLabel.text = NSLocalizedString(@"Pull to refresh...",);
         _titleLabel.font = [UIFont boldSystemFontOfSize:14];
         _titleLabel.backgroundColor = [UIColor clearColor];
@@ -313,7 +313,7 @@ static char UIScrollViewPullToRefreshView;
 
 - (UILabel *)subtitleLabel {
     if(!_subtitleLabel) {
-        _subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 28, 180, 20)];
+        _subtitleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 28, 210, 20)];
         _subtitleLabel.font = [UIFont systemFontOfSize:12];
         _subtitleLabel.backgroundColor = [UIColor clearColor];
         _subtitleLabel.textColor = textColor;


### PR DESCRIPTION
A subtitle string like "Last updated: 12/12/12, 12:58 PM" would truncate with the existing subtitle width, so I've widened the subtitle label width + made the title label the same width as well

before: https://www.evernote.com/shard/s2/sh/1747da80-f031-4b07-a3b5-89666fe1e7c0/554117f9c51f2d90455d6a5f9460daf3

after: https://www.evernote.com/shard/s2/sh/551ece60-5d25-4140-9192-c4cc14ae7c75/5f6b827b991c1382a5f18d30a4f25377

(background colors in the screen shots simply to show the dimensions...not in committed code)
