### PR TITLE
Infinite scroll position is wrong if showsInfiniteScroll = NO and showsInfiniteScroll = YES after

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -99,6 +99,9 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         [self addObserver:self.infiniteScrollingView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
         [self.infiniteScrollingView setScrollViewContentInsetForInfiniteScrolling];
         self.infiniteScrollingView.isObserving = YES;
+          
+        [self.infiniteScrollingView setNeedsLayout];
+        self.infiniteScrollingView.frame = CGRectMake(0, self.contentSize.height, self.infiniteScrollingView.bounds.size.width, SVInfiniteScrollingViewHeight);
       }
     }
 }


### PR DESCRIPTION
If I set a handler for infinite scroll, but set showsInfiniteScroll =
NO, and after a while (loading data), set it to YES, it would be on
tableview's top (making tapping on its first row impossible)
