### PR TITLE
Fix stopAnimating to prevent unnecessary scrolling

### DIFF
--- a/SVPullToRefresh.podspec
+++ b/SVPullToRefresh.podspec
@@ -6,7 +6,8 @@ Pod::Spec.new do |s|
   s.summary  = 'Give pull-to-refresh to any UIScrollView with 1 line of code.'
   s.homepage = 'https://github.com/samvermette/SVPullToRefresh'
   s.author   = { 'Sam Vermette' => 'hello@samvermette.com' }
-  s.source   = { :git => 'https://github.com/pilot34/SVPullToRefresh.git' }
+  s.source   = { :git => 'https://github.com/samvermette/SVPullToRefresh.git',
+                 :tag => '0.2' }
 
   s.description = 'SVPullToRefresh allows you to easily add pull-to-refresh ' \
                   'functionality to any UIScrollView subclass with only 1 ' \

--- a/SVPullToRefresh.podspec
+++ b/SVPullToRefresh.podspec
@@ -6,8 +6,7 @@ Pod::Spec.new do |s|
   s.summary  = 'Give pull-to-refresh to any UIScrollView with 1 line of code.'
   s.homepage = 'https://github.com/samvermette/SVPullToRefresh'
   s.author   = { 'Sam Vermette' => 'hello@samvermette.com' }
-  s.source   = { :git => 'https://github.com/samvermette/SVPullToRefresh.git',
-                 :tag => '0.2' }
+  s.source   = { :git => 'https://github.com/pilot34/SVPullToRefresh.git' }
 
   s.description = 'SVPullToRefresh allows you to easily add pull-to-refresh ' \
                   'functionality to any UIScrollView subclass with only 1 ' \

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -442,7 +442,7 @@ static char UIScrollViewPullToRefreshView;
 - (void)stopAnimating {
     self.state = SVPullToRefreshStateStopped;
     
-    if(!self.wasTriggeredByUser)
+    if(!self.wasTriggeredByUser && self.scrollView.contentOffset.y < -self.originalTopInset)
         [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, -self.originalTopInset) animated:YES];
 }
 


### PR DESCRIPTION
I have search cell as first cell in my table view. And initially it is hidden by contentOffset.y = SearchCell.height.

But     [self.scrollView.pullToRefreshView stopAnimating]; showing my cell because it reset contentOffset.y. 

So i remove scrolling if it is unnecessary.
