### PR TITLE
Fixed setting a custom view left the older ones as subviews

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -205,6 +205,10 @@ static char UIScrollViewPullToRefreshView;
     self.arrow.hidden = hasCustomView;
     
     if(hasCustomView) {
+        for (UIView *subview in self.subviews) {
+            [subview removeFromSuperview];
+        }
+
         [self addSubview:customView];
         CGRect viewBounds = [customView bounds];
         CGPoint origin = CGPointMake(roundf((self.bounds.size.width-viewBounds.size.width)/2), roundf((self.bounds.size.height-viewBounds.size.height)/2));


### PR DESCRIPTION
I saw all of my custom views stayed in the view hierarchy even if I added a new one which replaces it. 

Now it wipes all subviews before it adds a custom one.
