### PR TITLE
Fix a typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These UIScrollView categories makes it super easy to add pull-to-refresh and inf
 
 * Drag the `SVPullToRefresh/SVPullToRefresh` folder into your project.
 * Add the **QuartzCore** framework to your project.
-* Import `UIScrollView+SVPullToRefresh.h` and/or `UIScrollView+SVInfiniteScrolling.m`
+* Import `UIScrollView+SVPullToRefresh.h` and/or `UIScrollView+SVInfiniteScrolling.h`
 
 ## Usage
 


### PR DESCRIPTION
The README referenced `UIScrollView+SVInfiniteScrolling.m` when it should be `UIScrollView+SVInfiniteScrolling.h`.
