### PR TITLE
Added option for pull to refresh from bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # SVPullToRefresh + SVInfiniteScrolling
 
-These UIScrollView categories makes it super easy to add pull-to-refresh and infinite scrolling fonctionalities to any UIScrollView (or any of its subclass). Instead of relying on delegates and/or subclassing `UIViewController`, SVPullToRefresh uses the Objective-C runtime to add the following 2 methods to `UIScrollView`:
+These UIScrollView categories makes it super easy to add pull-to-refresh and infinite scrolling fonctionalities to any UIScrollView (or any of its subclass). Instead of relying on delegates and/or subclassing `UIViewController`, SVPullToRefresh uses the Objective-C runtime to add the following 3 methods to `UIScrollView`:
 
 ```objective-c
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler;
+- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler position:(SVPullToRefreshPosition)position;
 - (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler;
 ```
 
@@ -32,6 +33,14 @@ _**Important note if your project doesn't use ARC**: you must add the `-fobjc-ar
     // prepend data to dataSource, insert cells at top of table view
     // call [tableView.pullToRefreshView stopAnimating] when done
 }];
+```
+or if you want pull to refresh from the bottom
+
+```objective-c
+[tableView addPullToRefreshWithActionHandler:^{
+    // prepend data to dataSource, insert cells at top of table view
+    // call [tableView.pullToRefreshView stopAnimating] when done
+} position:SVPullToRefreshPositionBottom];
 ```
 
 If you’d like to programmatically trigger the refresh (for instance in `viewDidAppear:`), you can do so with:

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
@@ -15,7 +15,15 @@
 
 @interface UIScrollView (SVPullToRefresh)
 
+enum {
+    SVPullToRefreshPositionTop = 0,
+    SVPullToRefreshPositionBottom,
+};
+
+typedef NSUInteger SVPullToRefreshPosition;
+
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler;
+- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler position:(SVPullToRefreshPosition)position;
 - (void)triggerPullToRefresh;
 
 @property (nonatomic, strong, readonly) SVPullToRefreshView *pullToRefreshView;
@@ -42,6 +50,7 @@ typedef NSUInteger SVPullToRefreshState;
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 
 @property (nonatomic, readonly) SVPullToRefreshState state;
+@property (nonatomic, readonly) SVPullToRefreshPosition position;
 
 - (void)setTitle:(NSString *)title forState:(SVPullToRefreshState)state;
 - (void)setSubtitle:(NSString *)subtitle forState:(SVPullToRefreshState)state;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -10,7 +10,8 @@
 #import <QuartzCore/QuartzCore.h>
 #import "UIScrollView+SVPullToRefresh.h"
 
-//fequalzro() from http://stackoverflow.com/a/1614761/184130
+//fequal() and fequalzro() from http://stackoverflow.com/a/1614761/184130
+#define fequal(a,b) (fabs((a) - (b)) < FLT_EPSILON)
 #define fequalzero(a) (fabs(a) < FLT_EPSILON)
 
 static CGFloat const SVPullToRefreshViewHeight = 60;
@@ -31,6 +32,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 @property (nonatomic, strong, readwrite) UILabel *titleLabel;
 @property (nonatomic, strong, readwrite) UILabel *subtitleLabel;
 @property (nonatomic, readwrite) SVPullToRefreshState state;
+@property (nonatomic, readwrite) SVPullToRefreshPosition position;
 
 @property (nonatomic, strong) NSMutableArray *titles;
 @property (nonatomic, strong) NSMutableArray *subtitles;
@@ -38,6 +40,7 @@ static CGFloat const SVPullToRefreshViewHeight = 60;
 
 @property (nonatomic, weak) UIScrollView *scrollView;
 @property (nonatomic, readwrite) CGFloat originalTopInset;
+@property (nonatomic, readwrite) CGFloat originalBottomInset;
 
 @property (nonatomic, assign) BOOL wasTriggeredByUser;
 @property (nonatomic, assign) BOOL showsPullToRefresh;
@@ -62,18 +65,36 @@ static char UIScrollViewPullToRefreshView;
 
 @dynamic pullToRefreshView, showsPullToRefresh;
 
-- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler {
+- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler position:(SVPullToRefreshPosition)position {
     
     if(!self.pullToRefreshView) {
-        SVPullToRefreshView *view = [[SVPullToRefreshView alloc] initWithFrame:CGRectMake(0, -SVPullToRefreshViewHeight, self.bounds.size.width, SVPullToRefreshViewHeight)];
+        CGFloat yOrigin;
+        switch (position) {
+            case SVPullToRefreshPositionTop:
+                yOrigin = -SVPullToRefreshViewHeight;
+                break;
+            case SVPullToRefreshPositionBottom:
+                yOrigin = self.contentSize.height;
+                break;
+            default:
+                return;
+        }
+        SVPullToRefreshView *view = [[SVPullToRefreshView alloc] initWithFrame:CGRectMake(0, yOrigin, self.bounds.size.width, SVPullToRefreshViewHeight)];
         view.pullToRefreshActionHandler = actionHandler;
         view.scrollView = self;
         [self addSubview:view];
         
         view.originalTopInset = self.contentInset.top;
+        view.originalBottomInset = self.contentInset.bottom;
+        view.position = position;
         self.pullToRefreshView = view;
         self.showsPullToRefresh = YES;
     }
+    
+}
+
+- (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler {
+    [self addPullToRefreshWithActionHandler:actionHandler position:SVPullToRefreshPositionTop];
 }
 
 - (void)triggerPullToRefresh {
@@ -97,19 +118,32 @@ static char UIScrollViewPullToRefreshView;
     self.pullToRefreshView.hidden = !showsPullToRefresh;
     
     if(!showsPullToRefresh) {
-      if (self.pullToRefreshView.isObserving) {
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
-        [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
-        [self.pullToRefreshView resetScrollViewContentInset];
-        self.pullToRefreshView.isObserving = NO;
-      }
+        if (self.pullToRefreshView.isObserving) {
+            [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
+            [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
+            [self.pullToRefreshView resetScrollViewContentInset];
+            self.pullToRefreshView.isObserving = NO;
+        }
     }
     else {
-      if (!self.pullToRefreshView.isObserving) {
-        [self addObserver:self.pullToRefreshView forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
-        [self addObserver:self.pullToRefreshView forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:nil];
-        self.pullToRefreshView.isObserving = YES;
-      }
+        if (!self.pullToRefreshView.isObserving) {
+            [self addObserver:self.pullToRefreshView forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
+            [self addObserver:self.pullToRefreshView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
+            [self addObserver:self.pullToRefreshView forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:nil];
+            self.pullToRefreshView.isObserving = YES;
+            
+            CGFloat yOrigin;
+            switch (self.pullToRefreshView.position) {
+                case SVPullToRefreshPositionTop:
+                    yOrigin = -SVPullToRefreshViewHeight;
+                    break;
+                case SVPullToRefreshPositionBottom:
+                    yOrigin = self.contentSize.height;
+                    break;
+            }
+            
+            self.pullToRefreshView.frame = CGRectMake(0, yOrigin, self.bounds.size.width, SVPullToRefreshViewHeight);
+        }
     }
 }
 
@@ -146,28 +180,29 @@ static char UIScrollViewPullToRefreshView;
         self.showsDateLabel = NO;
         
         self.titles = [NSMutableArray arrayWithObjects:NSLocalizedString(@"Pull to refresh...",),
-                                                       NSLocalizedString(@"Release to refresh...",),
-                                                       NSLocalizedString(@"Loading...",),
-                                                       nil];
+                             NSLocalizedString(@"Release to refresh...",),
+                             NSLocalizedString(@"Loading...",),
+                                nil];
         
         self.subtitles = [NSMutableArray arrayWithObjects:@"", @"", @"", @"", nil];
         self.viewForState = [NSMutableArray arrayWithObjects:@"", @"", @"", @"", nil];
     }
-
+    
     return self;
 }
 
-- (void)willMoveToSuperview:(UIView *)newSuperview { 
+- (void)willMoveToSuperview:(UIView *)newSuperview {
     if (self.superview && newSuperview == nil) {
         //use self.superview, not self.scrollView. Why self.scrollView == nil here?
         UIScrollView *scrollView = (UIScrollView *)self.superview;
         if (scrollView.showsPullToRefresh) {
-          if (self.isObserving) {
-            //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
-            [scrollView removeObserver:self forKeyPath:@"contentOffset"];
-            [scrollView removeObserver:self forKeyPath:@"frame"];
-            self.isObserving = NO;
-          }
+            if (self.isObserving) {
+                //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
+                [scrollView removeObserver:self forKeyPath:@"contentOffset"];
+                [scrollView removeObserver:self forKeyPath:@"contentSize"];
+                [scrollView removeObserver:self forKeyPath:@"frame"];
+                self.isObserving = NO;
+            }
         }
     }
 }
@@ -197,16 +232,37 @@ static char UIScrollViewPullToRefreshView;
             case SVPullToRefreshStateStopped:
                 self.arrow.alpha = 1;
                 [self.activityIndicatorView stopAnimating];
-                [self rotateArrow:0 hide:NO];
+                switch (self.position) {
+                    case SVPullToRefreshPositionTop:
+                        [self rotateArrow:0 hide:NO];
+                        break;
+                    case SVPullToRefreshPositionBottom:
+                        [self rotateArrow:(float)M_PI hide:NO];
+                        break;
+                }
                 break;
                 
             case SVPullToRefreshStateTriggered:
-                [self rotateArrow:(float)M_PI hide:NO];
+                switch (self.position) {
+                    case SVPullToRefreshPositionTop:
+                        [self rotateArrow:(float)M_PI hide:NO];
+                        break;
+                    case SVPullToRefreshPositionBottom:
+                        [self rotateArrow:0 hide:NO];
+                        break;
+                }
                 break;
                 
             case SVPullToRefreshStateLoading:
                 [self.activityIndicatorView startAnimating];
-                [self rotateArrow:0 hide:YES];
+                switch (self.position) {
+                    case SVPullToRefreshPositionTop:
+                        [self rotateArrow:0 hide:YES];
+                        break;
+                    case SVPullToRefreshPositionBottom:
+                        [self rotateArrow:(float)M_PI hide:YES];
+                        break;
+                }
                 break;
         }
         
@@ -264,14 +320,26 @@ static char UIScrollViewPullToRefreshView;
 
 - (void)resetScrollViewContentInset {
     UIEdgeInsets currentInsets = self.scrollView.contentInset;
-    currentInsets.top = self.originalTopInset;
+    switch (self.position) {
+        case SVPullToRefreshPositionTop:
+            currentInsets.top = self.originalTopInset;
+            break;
+        case SVPullToRefreshPositionBottom:
+            currentInsets.bottom = self.originalBottomInset;
+    }
     [self setScrollViewContentInset:currentInsets];
 }
 
 - (void)setScrollViewContentInsetForLoading {
     CGFloat offset = MAX(self.scrollView.contentOffset.y * -1, 0);
     UIEdgeInsets currentInsets = self.scrollView.contentInset;
-    currentInsets.top = MIN(offset, self.originalTopInset + self.bounds.size.height);
+    switch (self.position) {
+        case SVPullToRefreshPositionTop:
+            currentInsets.top = MIN(offset, self.originalTopInset + self.bounds.size.height);
+            break;
+        case SVPullToRefreshPositionBottom:
+            currentInsets.bottom = MIN(offset, self.originalBottomInset + self.bounds.size.height);
+    }
     [self setScrollViewContentInset:currentInsets];
 }
 
@@ -287,28 +355,67 @@ static char UIScrollViewPullToRefreshView;
 
 #pragma mark - Observing
 
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {    
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     if([keyPath isEqualToString:@"contentOffset"])
         [self scrollViewDidScroll:[[change valueForKey:NSKeyValueChangeNewKey] CGPointValue]];
+    else if([keyPath isEqualToString:@"contentSize"]) {
+        [self layoutSubviews];
+        
+        CGFloat yOrigin;
+        switch (self.position) {
+            case SVPullToRefreshPositionTop:
+                yOrigin = -SVPullToRefreshViewHeight;
+                break;
+            case SVPullToRefreshPositionBottom:
+                yOrigin = self.scrollView.contentSize.height;
+                break;
+        }
+        self.frame = CGRectMake(0, yOrigin, self.bounds.size.width, SVPullToRefreshViewHeight);
+    }
     else if([keyPath isEqualToString:@"frame"])
         [self layoutSubviews];
+
 }
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
     if(self.state != SVPullToRefreshStateLoading) {
-        CGFloat scrollOffsetThreshold = self.frame.origin.y-self.originalTopInset;
+        CGFloat scrollOffsetThreshold;
+        switch (self.position) {
+            case SVPullToRefreshPositionTop:
+                scrollOffsetThreshold = self.frame.origin.y-self.originalTopInset;
+                break;
+            case SVPullToRefreshPositionBottom:
+                scrollOffsetThreshold = self.scrollView.contentSize.height - self.scrollView.bounds.size.height + self.bounds.size.height + self.originalBottomInset;
+                break;
+        }
         
         if(!self.scrollView.isDragging && self.state == SVPullToRefreshStateTriggered)
             self.state = SVPullToRefreshStateLoading;
-        else if(contentOffset.y < scrollOffsetThreshold && self.scrollView.isDragging && self.state == SVPullToRefreshStateStopped)
+        else if(contentOffset.y < scrollOffsetThreshold && self.scrollView.isDragging && self.state == SVPullToRefreshStateStopped && self.position == SVPullToRefreshPositionTop)
             self.state = SVPullToRefreshStateTriggered;
-        else if(contentOffset.y >= scrollOffsetThreshold && self.state != SVPullToRefreshStateStopped)
+        else if(contentOffset.y >= scrollOffsetThreshold && self.state != SVPullToRefreshStateStopped && self.position == SVPullToRefreshPositionTop)
+            self.state = SVPullToRefreshStateStopped;
+        else if(contentOffset.y > scrollOffsetThreshold && self.scrollView.isDragging && self.state == SVPullToRefreshStateStopped && self.position == SVPullToRefreshPositionBottom)
+            self.state = SVPullToRefreshStateTriggered;
+        else if(contentOffset.y <= scrollOffsetThreshold && self.state != SVPullToRefreshStateStopped && self.position == SVPullToRefreshPositionBottom)
             self.state = SVPullToRefreshStateStopped;
     } else {
-        CGFloat offset = MAX(self.scrollView.contentOffset.y * -1, 0.0f);
-        offset = MIN(offset, self.originalTopInset + self.bounds.size.height);
-        UIEdgeInsets contentInset = self.scrollView.contentInset;
-        self.scrollView.contentInset = UIEdgeInsetsMake(offset, contentInset.left, contentInset.bottom, contentInset.right);
+        CGFloat offset;
+        UIEdgeInsets contentInset;
+        switch (self.position) {
+            case SVPullToRefreshPositionTop:
+                offset = MAX(self.scrollView.contentOffset.y * -1, 0.0f);
+                offset = MIN(offset, self.originalTopInset + self.bounds.size.height);
+                contentInset = self.scrollView.contentInset;
+                self.scrollView.contentInset = UIEdgeInsetsMake(offset, contentInset.left, contentInset.bottom, contentInset.right);
+                break;
+            case SVPullToRefreshPositionBottom:
+                offset = MAX(self.scrollView.contentSize.height - self.scrollView.bounds.size.height + self.bounds.size.height, 0.0f);
+                offset = MIN(offset, self.originalBottomInset + self.bounds.size.height);
+                contentInset = self.scrollView.contentInset;
+                self.scrollView.contentInset = UIEdgeInsetsMake(contentInset.top, contentInset.left, offset, contentInset.right);
+                break;
+        }
     }
 }
 
@@ -453,12 +560,28 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (void)startAnimating{
-    if(fequalzero(self.scrollView.contentOffset.y)) {
-        [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, -self.frame.size.height) animated:YES];
-        self.wasTriggeredByUser = NO;
+    switch (self.position) {
+        case SVPullToRefreshPositionTop:
+            
+            if(fequalzero(self.scrollView.contentOffset.y)) {
+                [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, -self.frame.size.height) animated:YES];
+                self.wasTriggeredByUser = NO;
+            }
+            else
+                self.wasTriggeredByUser = YES;
+            
+            break;
+        case SVPullToRefreshPositionBottom:
+            
+            if(fequal(self.scrollView.contentOffset.y, self.scrollView.contentSize.height - self.scrollView.bounds.size.height)) {
+                [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, self.scrollView.contentSize.height - self.scrollView.bounds.size.height + self.frame.size.height) animated:YES];
+                self.wasTriggeredByUser = NO;
+            }
+            else
+                self.wasTriggeredByUser = YES;
+            
+            break;
     }
-    else
-        self.wasTriggeredByUser = YES;
     
     self.state = SVPullToRefreshStateLoading;
 }
@@ -466,8 +589,16 @@ static char UIScrollViewPullToRefreshView;
 - (void)stopAnimating {
     self.state = SVPullToRefreshStateStopped;
     
-    if(!self.wasTriggeredByUser && self.scrollView.contentOffset.y < -self.originalTopInset)
-        [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, -self.originalTopInset) animated:YES];
+    switch (self.position) {
+        case SVPullToRefreshPositionTop:
+            if(!self.wasTriggeredByUser && self.scrollView.contentOffset.y < -self.originalTopInset)
+                [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, -self.originalTopInset) animated:YES];
+            break;
+        case SVPullToRefreshPositionBottom:
+            if(!self.wasTriggeredByUser && self.scrollView.contentOffset.y < -self.originalTopInset)
+                [self.scrollView setContentOffset:CGPointMake(self.scrollView.contentOffset.x, self.scrollView.contentSize.height - self.scrollView.bounds.size.height + self.originalBottomInset) animated:YES];
+            break;
+    }
 }
 
 - (void)setState:(SVPullToRefreshState)newState {


### PR DESCRIPTION
Added `-addPullToRefreshWithActionHandler:position:` which takes a `SVPullToRefreshPosition` as second parameter.

`SVPullToRefreshPosition` may be either:
- `SVPullToRefreshPositionTop` : pull to refresh from the top of the scroll view (the current behavior)
- `SVPullToRefreshPositionBottom` : pull to refresh from the bottom of the scroll view

`-addPullToRefreshWithActionHandler:` defaults on `SVPullToRefreshTop`, making this update fully backward compatible.

---

Example

```
[self.tableView addPullToRefreshWithActionHandler:^{
   // ...
} position:SVPullToRefreshPositionBottom];
```

will result in the following behavior

![SVPullToRefresh from bottom](http://f.cl.ly/items/1w0z2x2Z3v1Q2c0X0k1X/SVPullToRefreshBottom.png)
