### PR TITLE
Added option for infinite scrolling at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # SVPullToRefresh + SVInfiniteScrolling
 
-These UIScrollView categories makes it super easy to add pull-to-refresh and infinite scrolling fonctionalities to any UIScrollView (or any of its subclass). Instead of relying on delegates and/or subclassing `UIViewController`, SVPullToRefresh uses the Objective-C runtime to add the following 3 methods to `UIScrollView`:
+These UIScrollView categories makes it super easy to add pull-to-refresh and infinite scrolling fonctionalities to any UIScrollView (or any of its subclass). Instead of relying on delegates and/or subclassing `UIViewController`, SVPullToRefresh uses the Objective-C runtime to add the following 4 methods to `UIScrollView`:
 
 ```objective-c
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler;
 - (void)addPullToRefreshWithActionHandler:(void (^)(void))actionHandler position:(SVPullToRefreshPosition)position;
 - (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler;
+- (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler direction:(SVInfiniteScrollingDirection)direction;
 ```
 
 ## Installation
@@ -84,6 +85,14 @@ tableView.pullToRefreshView.arrowColor = [UIColor whiteColor];
     // append data to data source, insert new cells at the end of table view
     // call [tableView.infiniteScrollingView stopAnimating] when done
 }];
+```
+or if you want infinite scrolling at the top
+
+```objective-c
+[tableView addInfiniteScrollingWithActionHandler:^{
+    // append data to data source, insert new cells at the end of table view
+    // call [tableView.infiniteScrollingView stopAnimating] when done
+} direction:SVInfiniteScrollingDirectionTop];
 ```
 
 If you’d like to programmatically trigger the loading (for instance in `viewDidAppear:`), you can do so with:

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
@@ -13,7 +13,15 @@
 
 @interface UIScrollView (SVInfiniteScrolling)
 
+enum {
+    SVInfiniteScrollingDirectionBottom = 0,
+    SVInfiniteScrollingDirectionTop,
+};
+
+typedef NSUInteger SVInfiniteScrollingDirection;
+
 - (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler;
+- (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler direction:(SVInfiniteScrollingDirection)direction;
 - (void)triggerInfiniteScrolling;
 
 @property (nonatomic, strong, readonly) SVInfiniteScrollingView *infiniteScrollingView;
@@ -35,6 +43,7 @@ typedef NSUInteger SVInfiniteScrollingState;
 
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 @property (nonatomic, readonly) SVInfiniteScrollingState state;
+@property (nonatomic, readonly) SVInfiniteScrollingDirection direction;
 @property (nonatomic, readwrite) BOOL enabled;
 
 - (void)setCustomView:(UIView *)view forState:(SVInfiniteScrollingState)state;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -327,7 +327,6 @@ static char UIScrollViewPullToRefreshView;
             break;
         case SVPullToRefreshPositionBottom:
             currentInsets.bottom = self.originalBottomInset;
-            currentInsets.top = self.originalTopInset;
             break;
     }
     [self setScrollViewContentInset:currentInsets];


### PR DESCRIPTION
Added `-addInfiniteScrollingWithActionHandler:direction:` which takes a `SVInfiniteScrollingDirection` as second parameter.

`SVInfiniteScrollingDirection` may be either:
- `SVInfiniteScrollingDirectionBottom` : pull to refresh from the top of the scroll view (the current behavior)
- `SVInfiniteScrollingDirectionTop` : pull to refresh from the bottom of the scroll view

`-addInfiniteScrollingWithActionHandler:` defaults on `SVInfiniteScrollingDirectionBottom`, making this update fully backward compatible.

This completes the work started in https://github.com/samvermette/SVPullToRefresh/pull/123, so that an infinite scrolling at the top can be combined with a pull to refresh at the bottom.

---

Example

```
[self.tableView addInfiniteScrollingWithActionHandler:^{
    [weakSelf insertRowAtBottom];
} direction:SVInfiniteScrollingDirectionTop];
```

will result in the following behavior

![SVPullToRefresh from bottom](http://f.cl.ly/items/35141l3z1N0H0u0F3y2m/Screen%20Shot%202013-05-25%20at%203.00.03%20PM.png)
