### PR TITLE
Fixes a bug when view gets deallocated & showsPullToRefresh == NO

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -204,7 +204,8 @@ static char UIScrollViewPullToRefreshView;
                 [scrollView removeObserver:self forKeyPath:@"frame"];
                 self.isObserving = NO;
             }
-        }
+        } else
+            [scrollView removeObserver:self forKeyPath:@"contentSize"];
     }
 }
 


### PR DESCRIPTION
Observers were not correctly removed if `showsPullToRefresh` equals to NO.

This error what appearing :

"An instance 0x78b6e00 of class UITableView was deallocated while key value observers were still registered with it. Observation info was leaked, and may even become mistakenly attached to some other object. Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger."

This fixes the issue.

Cheers
