### PR TITLE
Observation handler remove - one lost line of code

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -120,6 +120,7 @@ static char UIScrollViewPullToRefreshView;
     if(!showsPullToRefresh) {
         if (self.pullToRefreshView.isObserving) {
             [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
+            [self removeObserver:self.pullToRefreshView forKeyPath:@"contentSize"];
             [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
             [self.pullToRefreshView resetScrollViewContentInset];
             self.pullToRefreshView.isObserving = NO;


### PR DESCRIPTION
Without added line getting error: "An instance 0xab63600 of class
UITableView was deallocated while key value observers were still
registered with it. Observation info was leaked, and may even become
mistakenly attached to some other object. Set a breakpoint on
NSKVODeallocateBreak to stop here in the debugger. Here's the current
observation info:
<NSKeyValueObservationInfo 0xb070bd0> (
<NSKeyValueObservance 0xb1aba60: Observer: 0xb1aaf50, Key path:
contentSize, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0,
Property: 0xb082850>
<NSKeyValueObservance 0xb1aba60: Observer: 0xb1aaf50, Key path:
contentSize, Options: <New: YES, Old: NO, Prior: NO> Context: 0x0,
Property: 0xb082850>
)" when hidding tableview with PullToRefresh handler.
