### PR TITLE
Add support for setting UIActivityIndicatorView color (iOS 5+)

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
@@ -47,6 +47,7 @@ typedef NSUInteger SVPullToRefreshState;
 @property (nonatomic, strong) UIColor *textColor;
 @property (nonatomic, strong, readonly) UILabel *titleLabel;
 @property (nonatomic, strong, readonly) UILabel *subtitleLabel;
+@property (nonatomic, strong) UIColor *activityIndicatorViewColor;
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 
 @property (nonatomic, readonly) SVPullToRefreshState state;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
@@ -47,7 +47,7 @@ typedef NSUInteger SVPullToRefreshState;
 @property (nonatomic, strong) UIColor *textColor;
 @property (nonatomic, strong, readonly) UILabel *titleLabel;
 @property (nonatomic, strong, readonly) UILabel *subtitleLabel;
-@property (nonatomic, strong) UIColor *activityIndicatorViewColor;
+@property (nonatomic, strong, readwrite) UIColor *activityIndicatorViewColor NS_AVAILABLE_IOS(5_0);
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 
 @property (nonatomic, readonly) SVPullToRefreshState state;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -157,7 +157,7 @@ static char UIScrollViewPullToRefreshView;
 @implementation SVPullToRefreshView
 
 // public properties
-@synthesize pullToRefreshActionHandler, arrowColor, textColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter;
+@synthesize pullToRefreshActionHandler, arrowColor, textColor, activityIndicatorViewColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter;
 
 @synthesize state = _state;
 @synthesize scrollView = _scrollView;
@@ -494,6 +494,10 @@ static char UIScrollViewPullToRefreshView;
     return self.titleLabel.textColor;
 }
 
+- (UIColor *)activityIndicatorViewColor {
+    return self.activityIndicatorView.color;
+}
+
 - (UIActivityIndicatorViewStyle)activityIndicatorViewStyle {
     return self.activityIndicatorView.activityIndicatorViewStyle;
 }
@@ -547,6 +551,10 @@ static char UIScrollViewPullToRefreshView;
     textColor = newTextColor;
     self.titleLabel.textColor = newTextColor;
 	self.subtitleLabel.textColor = newTextColor;
+}
+
+- (void)setActivityIndicatorViewColor:(UIColor *)color {
+    self.activityIndicatorView.color = color;
 }
 
 - (void)setActivityIndicatorViewStyle:(UIActivityIndicatorViewStyle)viewStyle {


### PR DESCRIPTION
Considering everything else can be customized, I figured it would be nice to add support for setting a custom color for the UIActivityIndicatorView so that user's aren't constrained to either white or gray.
