### PR TITLE
Animate activityIndicatorView as soon as the view appears

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -288,6 +288,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
                 break;
                 
             case SVInfiniteScrollingStateTriggered:
+                [self.activityIndicatorView startAnimating];
                 break;
                 
             case SVInfiniteScrollingStateLoading:


### PR DESCRIPTION
Currently you need to scroll to the bottom and wait until isDragging is NO before the activityIndicatorView appears (or more technically, before the SVInfiniteScrollingState changes to 'loading'); making the view appear one step behind a user's scroll.

This just starts the animation as soon as the state is 'triggered', so the activity indicator view appears immediately.
