### PR TITLE
Centralise arrow when the text is empty

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -289,7 +289,14 @@ static char UIScrollViewPullToRefreshView;
                                                       lineBreakMode:self.subtitleLabel.lineBreakMode];
         
         CGFloat maxLabelWidth = MAX(titleSize.width,subtitleSize.width);
-        CGFloat totalMaxWidth = leftViewWidth + margin + maxLabelWidth;
+        
+        CGFloat totalMaxWidth;
+        if (maxLabelWidth) {
+        	totalMaxWidth = leftViewWidth + margin + maxLabelWidth;
+        } else {
+        	totalMaxWidth = leftViewWidth + maxLabelWidth;
+        }
+        
         CGFloat labelX = (self.bounds.size.width / 2) - (totalMaxWidth / 2) + leftViewWidth + margin;
         
         if(subtitleSize.height > 0){


### PR DESCRIPTION
Avoiding to add a margin to the arrow when the title text is empty. 
This will make the arrow centralised in the screen when there is no text.
When there is text, the margin continues to be used.
