### PR TITLE
Disable infinite scroll view if the content height is less than the frame height

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -61,7 +61,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         
         view.originalBottomInset = self.contentInset.bottom;
         self.infiniteScrollingView = view;
-        self.showsInfiniteScrolling = YES;
+        self.showsInfiniteScrolling = self.contentSize.height < self.frame.size.height ? NO : YES;
     }
 }
 


### PR DESCRIPTION
This fixed #119 for me by applying your recommended change which was to disable the scrollview if the content height was smaller than the frame height.
