### PR TITLE
fix bug: pull refresh action will tragger infinite view when the content height is less than the frame height

### DIFF
--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -26,24 +26,26 @@
     
     // setup pull-to-refresh
     [self.tableView addPullToRefreshWithActionHandler:^{
+        NSLog(@"refresh top");
         [weakSelf insertRowAtTop];
     }];
         
     // setup infinite scrolling
     [self.tableView addInfiniteScrollingWithActionHandler:^{
+        NSLog(@"refresh bottom");
         [weakSelf insertRowAtBottom];
     }];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
-    [tableView triggerPullToRefresh];
+//    [tableView triggerPullToRefresh];
 }
 
 #pragma mark - Actions
 
 - (void)setupDataSource {
     self.dataSource = [NSMutableArray array];
-    for(int i=0; i<15; i++)
+    for(int i=0; i<4; i++)
         [self.dataSource addObject:[NSDate dateWithTimeIntervalSinceNow:-(i*90)]];
 }
 

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -192,6 +192,9 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 }
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
+    if (contentOffset.y<=0) {//negative means pull
+        return;
+    }
     if(self.state != SVInfiniteScrollingStateLoading && self.enabled) {
         CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
         CGFloat scrollOffsetThreshold = scrollViewContentHeight-self.scrollView.bounds.size.height;


### PR DESCRIPTION
I just add a if block.

> if (contentOffset.y<=0) {//negative means pull
>        return;
>    }

And I've change the Demo code and you can test it
