### PR TITLE
fixed bug: when settnig the custom view it was not removing the old view from the parent

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -34,7 +34,7 @@ static CGFloat const SVInfiniteScrollingViewHeight = 60;
 @property (nonatomic, assign) BOOL isObserving;
 
 - (void)resetScrollViewContentInset;
-- (void)setScrollViewContentInsetForInfiniteScrolling;
+- (void)setScrollViewContentInsetForInfiniteScrolling:(CGFloat)newInsetBottomHeight;
 - (void)setScrollViewContentInset:(UIEdgeInsets)insets;
 
 @end
@@ -97,7 +97,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
       if (!self.infiniteScrollingView.isObserving) {
         [self addObserver:self.infiniteScrollingView forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
         [self addObserver:self.infiniteScrollingView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
-        [self.infiniteScrollingView setScrollViewContentInsetForInfiniteScrolling];
+          [self.infiniteScrollingView setScrollViewContentInsetForInfiniteScrolling:SVInfiniteScrollingViewHeight];
         self.infiniteScrollingView.isObserving = YES;
           
         [self.infiniteScrollingView setNeedsLayout];
@@ -164,9 +164,9 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     [self setScrollViewContentInset:currentInsets];
 }
 
-- (void)setScrollViewContentInsetForInfiniteScrolling {
+- (void)setScrollViewContentInsetForInfiniteScrolling:(CGFloat)newInsetBottomHeight {
     UIEdgeInsets currentInsets = self.scrollView.contentInset;
-    currentInsets.bottom = self.originalBottomInset + SVInfiniteScrollingViewHeight;
+    currentInsets.bottom = self.originalBottomInset + newInsetBottomHeight;
     [self setScrollViewContentInset:currentInsets];
 }
 
@@ -236,8 +236,8 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         [self.viewForState replaceObjectsInRange:NSMakeRange(0, 3) withObjectsFromArray:@[viewPlaceholder, viewPlaceholder, viewPlaceholder]];
     } else {
 		id otherView = [self.viewForState objectAtIndex:state];
-		 if([otherView isKindOfClass:[UIView class]])
-	            [otherView removeFromSuperview];
+		if([otherView isKindOfClass:[UIView class]])
+            [otherView removeFromSuperview];
         [self.viewForState replaceObjectAtIndex:state withObject:viewPlaceholder];
     }
     self.state = self.state;
@@ -280,9 +280,10 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     
     if(hasCustomView) {
         [self addSubview:customView];
-        CGRect viewBounds = [customView bounds];
-        CGPoint origin = CGPointMake(roundf((self.bounds.size.width-viewBounds.size.width)/2), roundf((self.bounds.size.height-viewBounds.size.height)/2));
-        [customView setFrame:CGRectMake(origin.x, origin.y, viewBounds.size.width, viewBounds.size.height)];
+        [self setScrollViewContentInsetForInfiniteScrolling:(((UIView *)customView).frame.size.height+SVInfiniteScrollingViewHeight)];
+      //  CGRect viewBounds = [customView bounds];
+      //  CGPoint origin = CGPointMake(roundf((self.bounds.size.width-viewBounds.size.width)/2), roundf((self.bounds.size.height-viewBounds.size.height)/2));
+      //  [customView setFrame:CGRectMake(origin.x, origin.y, viewBounds.size.width, viewBounds.size.height)];
     }
     else {
         CGRect viewBounds = [self.activityIndicatorView bounds];

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -236,7 +236,8 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         [self.viewForState replaceObjectsInRange:NSMakeRange(0, 3) withObjectsFromArray:@[viewPlaceholder, viewPlaceholder, viewPlaceholder]];
     } else {
 		id otherView = [self.viewForState objectAtIndex:state];
-		[otherView removeFromSuperview]; 
+		 if([otherView isKindOfClass:[UIView class]])
+	            [otherView removeFromSuperview];
         [self.viewForState replaceObjectAtIndex:state withObject:viewPlaceholder];
     }
     self.state = self.state;

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -228,11 +228,17 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     if(!viewPlaceholder)
         viewPlaceholder = @"";
     
-    if(state == SVInfiniteScrollingStateAll)
+    if(state == SVInfiniteScrollingStateAll) {
+		for(id otherView in self.viewForState) {
+	        if([otherView isKindOfClass:[UIView class]])
+	            [otherView removeFromSuperview];
+	    }
         [self.viewForState replaceObjectsInRange:NSMakeRange(0, 3) withObjectsFromArray:@[viewPlaceholder, viewPlaceholder, viewPlaceholder]];
-    else
+    } else {
+		id otherView = [self.viewForState objectAtIndex:state];
+		[otherView removeFromSuperview]; 
         [self.viewForState replaceObjectAtIndex:state withObject:viewPlaceholder];
-    
+    }
     self.state = self.state;
 }
 


### PR DESCRIPTION
If you want to replace a custom view with a new custom view, the old views were never removedFromSuperview.  This commit adds in the lines to do just that when a new customView is set
