### PR TITLE
Prevent crashing after setShowsInfiniteScrolling:NO twice

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -89,8 +89,8 @@ UIEdgeInsets scrollViewOriginalContentInsets;
       if (self.infiniteScrollingView.isObserving) {
         [self removeObserver:self.infiniteScrollingView forKeyPath:@"contentOffset"];
         [self removeObserver:self.infiniteScrollingView forKeyPath:@"contentSize"];
-        [self.infiniteScrollingView resetScrollViewContentInset];
         self.infiniteScrollingView.isObserving = NO;
+        [self.infiniteScrollingView resetScrollViewContentInset];
       }
     }
     else {


### PR DESCRIPTION
My app was crashing after calling `[tableView setShowsInfiniteScrolling:NO]` twice before re-setting to `YES`.
I'm not sure why this happened, but apparently `self.infiniteScrollingView.isObserving` was not being set to `NO`. So I swapped a couple of lines and it works again.
