### PR TITLE
Add infinite scrolling with action handler always

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -53,9 +53,10 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 
 - (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler {
     
-    if(!self.infiniteScrollingView) {
-        SVInfiniteScrollingView *view = [[SVInfiniteScrollingView alloc] initWithFrame:CGRectMake(0, self.contentSize.height, self.bounds.size.width, SVInfiniteScrollingViewHeight)];
-        view.infiniteScrollingHandler = actionHandler;
+    SVInfiniteScrollingView *view = self.infiniteScrollingView;
+    
+    if(!view) {
+        view = [[SVInfiniteScrollingView alloc] initWithFrame:CGRectMake(0, self.contentSize.height, self.bounds.size.width, SVInfiniteScrollingViewHeight)];
         view.scrollView = self;
         [self addSubview:view];
         
@@ -63,6 +64,8 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         self.infiniteScrollingView = view;
         self.showsInfiniteScrolling = YES;
     }
+    
+    view.infiniteScrollingHandler = actionHandler;
 }
 
 - (void)triggerInfiniteScrolling {


### PR DESCRIPTION
**Possibility to change the action handler more than once**
In cases where it is necessary to change the scroll action.

**Example:**

A table view display all items of some category. 
When `viewDidLoad`, `addInfiniteScrollingWithActionHandler` is called and loads the items for this category.

This screen has a picker that contains subcategories.
When the user selects one of these subcategories, the action handler for table view needs be changed to load the items from subcategory, ie it's necessary add a new action, without changing the view.
