### PR TITLE
Allow Content Inset to be Modified

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
@@ -38,6 +38,7 @@ typedef NSUInteger SVInfiniteScrollingState;
 @property (nonatomic, readwrite) BOOL enabled;
 
 - (void)setCustomView:(UIView *)view forState:(SVInfiniteScrollingState)state;
+- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset;
 
 - (void)startAnimating;
 - (void)stopAnimating;

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
@@ -16,8 +16,10 @@
 - (void)addInfiniteScrollingWithActionHandler:(void (^)(void))actionHandler;
 - (void)triggerInfiniteScrolling;
 
+- (void)setShowsInfiniteScrolling:(BOOL)showsInfiniteScrolling animated:(BOOL)animated;
+
 @property (nonatomic, strong, readonly) SVInfiniteScrollingView *infiniteScrollingView;
-@property (nonatomic, assign) BOOL showsInfiniteScrolling;
+@property (nonatomic, assign) BOOL showsInfiniteScrolling; // animated
 
 @end
 
@@ -38,7 +40,7 @@ typedef NSUInteger SVInfiniteScrollingState;
 @property (nonatomic, readwrite) BOOL enabled;
 
 - (void)setCustomView:(UIView *)view forState:(SVInfiniteScrollingState)state;
-- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset;
+- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset animated:(BOOL)animated;
 
 - (void)startAnimating;
 - (void)stopAnimating;

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -247,6 +247,18 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     self.state = SVInfiniteScrollingStateLoading;
 }
 
+- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset {
+	if (self.originalBottomInset == newOriginalContentInset.bottom) return;
+
+	self.originalBottomInset = newOriginalContentInset.bottom;
+	if (self.isHidden) {
+		[self resetScrollViewContentInset];
+	}
+	else {
+		[self setScrollViewContentInsetForInfiniteScrolling];
+	}
+}
+
 - (void)startAnimating{
     self.state = SVInfiniteScrollingStateLoading;
 }

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
@@ -46,6 +46,7 @@ typedef NSUInteger SVPullToRefreshState;
 - (void)setTitle:(NSString *)title forState:(SVPullToRefreshState)state;
 - (void)setSubtitle:(NSString *)subtitle forState:(SVPullToRefreshState)state;
 - (void)setCustomView:(UIView *)view forState:(SVPullToRefreshState)state;
+- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset;
 
 - (void)startAnimating;
 - (void)stopAnimating;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -402,6 +402,14 @@ static char UIScrollViewPullToRefreshView;
     [self setNeedsLayout];
 }
 
+- (void)updateOriginalContentInset:(UIEdgeInsets)newOriginalContentInset {
+	if (self.originalTopInset == newOriginalContentInset.top) return;
+
+	self.originalTopInset = newOriginalContentInset.top;
+	// doing nothing else for now
+}
+
+
 - (void)setTextColor:(UIColor *)newTextColor {
     textColor = newTextColor;
     self.titleLabel.textColor = newTextColor;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -94,6 +94,11 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (void)setShowsPullToRefresh:(BOOL)showsPullToRefresh {
+	// avoid starting to observe when not even having a pullToRefreshView, as this would result in a crash when the tableView deallocates later
+	if (self.pullToRefreshView == nil) {
+		return;
+	}
+	
     self.pullToRefreshView.hidden = !showsPullToRefresh;
     
     if(!showsPullToRefresh) {


### PR DESCRIPTION
I have advertising stickies that can dynamically be added to scroll & collection views. When an ad is loaded/removed, I set the content inset of the scroll view. Unfortunately InfiniteScrolling interferes with that, as it stores the original bottom inset once and forever.

As a workaround I added a method to SVInfiniteScrolling and SVPullToRefresh to be able to modify the content insets.

I'm not too happy about this solution, as a client class is disallowed to change contentInset properties directly.
I also tried using KVO, but then SVInfiniteScrolling and SVPullToRefresh would counterwise trigger an infinite KVO storm.

Any other ideas?
