### PR TITLE
fix bug:when call triggerPullToRefresh, the state will always be SVPullT...

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -610,8 +610,6 @@ static char UIScrollViewPullToRefreshView;
             
             break;
     }
-    
-    self.state = SVPullToRefreshStateLoading;
 }
 
 - (void)stopAnimating {


### PR DESCRIPTION
## fix bug

when call triggerPullToRefresh, the state will always be SVPullToRefreshStateLoading.
