### PR TITLE
Update contentInset properly, set a specific size for the pull to refresh view

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -202,6 +202,7 @@ static char UIScrollViewPullToRefreshView;
         if (scrollView.showsPullToRefresh) {
             if (self.isObserving) {
                 //If enter this branch, it is the moment just before "SVPullToRefreshView's dealloc", so remove observer here
+                [scrollView removeObserver:self forKeyPath:@"contentInset"];
                 [scrollView removeObserver:self forKeyPath:@"contentOffset"];
                 [scrollView removeObserver:self forKeyPath:@"contentSize"];
                 [scrollView removeObserver:self forKeyPath:@"frame"];

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -14,7 +14,7 @@
 #define fequal(a,b) (fabs((a) - (b)) < FLT_EPSILON)
 #define fequalzero(a) (fabs(a) < FLT_EPSILON)
 
-static CGFloat const SVPullToRefreshViewHeight = 60;
+static CGFloat const SVPullToRefreshViewHeight = 90;
 
 @interface SVPullToRefreshArrow : UIView
 
@@ -119,6 +119,7 @@ static char UIScrollViewPullToRefreshView;
     
     if(!showsPullToRefresh) {
         if (self.pullToRefreshView.isObserving) {
+            [self removeObserver:self.pullToRefreshView forKeyPath:@"contentInset"];
             [self removeObserver:self.pullToRefreshView forKeyPath:@"contentOffset"];
             [self removeObserver:self.pullToRefreshView forKeyPath:@"contentSize"];
             [self removeObserver:self.pullToRefreshView forKeyPath:@"frame"];
@@ -128,6 +129,7 @@ static char UIScrollViewPullToRefreshView;
     }
     else {
         if (!self.pullToRefreshView.isObserving) {
+            [self addObserver:self.pullToRefreshView forKeyPath:@"contentInset" options:NSKeyValueObservingOptionNew context:nil];
             [self addObserver:self.pullToRefreshView forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:nil];
             [self addObserver:self.pullToRefreshView forKeyPath:@"contentSize" options:NSKeyValueObservingOptionNew context:nil];
             [self addObserver:self.pullToRefreshView forKeyPath:@"frame" options:NSKeyValueObservingOptionNew context:nil];
@@ -385,8 +387,15 @@ static char UIScrollViewPullToRefreshView;
         }
         self.frame = CGRectMake(0, yOrigin, self.bounds.size.width, SVPullToRefreshViewHeight);
     }
-    else if([keyPath isEqualToString:@"frame"])
+    else if([keyPath isEqualToString:@"frame"]) {
         [self layoutSubviews];
+    }
+    else if ([keyPath isEqualToString:@"contentInset"]) {
+        if (self.state != SVPullToRefreshStateLoading) {
+            self.originalTopInset = self.scrollView.contentInset.top;
+            self.originalBottomInset = self.scrollView.contentInset.bottom;
+        }
+    }
 
 }
 


### PR DESCRIPTION
Hi @samvermette,
Here's a pull to request to update the value of the contentInset when it's modified after the pull to refresh view has been created.
(Alternative implementation would be to add a method to update originalInsetTop and originalInsetBottom).
Also, I hardcoded a new value for the size of the pull to refresh view. Of course, that's probably not the right thing to do. Do you recommend a way to move forward to be able to customize its size?
My goal when changing the size was to move the arrow outside of the screen since I changed the contentInset value of my table view.
