### PR TITLE
[FIX] you always must call super from layoutSubview implementation

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
@@ -42,4 +42,9 @@ typedef NSUInteger SVInfiniteScrollingState;
 - (void)startAnimating;
 - (void)stopAnimating;
 
+// i need them outside to correctly calculate rows visibility in tableview when using scrollToRowAtIndexPath
+- (void)resetScrollViewContentInset;
+- (void)setScrollViewContentInsetForInfiniteScrolling;
+
+
 @end

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -153,6 +153,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 }
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
     self.activityIndicatorView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
 }
 

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -33,8 +33,6 @@ static CGFloat const SVInfiniteScrollingViewHeight = 60;
 @property (nonatomic, assign) BOOL wasTriggeredByUser;
 @property (nonatomic, assign) BOOL isObserving;
 
-- (void)resetScrollViewContentInset;
-- (void)setScrollViewContentInsetForInfiniteScrolling;
 - (void)setScrollViewContentInset:(UIEdgeInsets)insets;
 
 @end

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -210,6 +210,7 @@ static char UIScrollViewPullToRefreshView;
 }
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
     
     for(id otherView in self.viewForState) {
         if([otherView isKindOfClass:[UIView class]])


### PR DESCRIPTION
Missing super is leading to this:

/SourceCache/UIKit_Sim/UIKit-2372/UIView.m:5776

**\* Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Auto Layout still required after executing -layoutSubviews.
