### PR TITLE
Infinite scrolling no longer triggered inappropriately when the scroll view's content size is taller than its frame's height.

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -193,9 +193,10 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
     if(self.state != SVInfiniteScrollingStateLoading && self.enabled) {
-        CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
-        CGFloat scrollOffsetThreshold = scrollViewContentHeight-self.scrollView.bounds.size.height;
-        
+		CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
+		CGFloat scrollOffsetThresholdMax = MAX(scrollViewContentHeight, self.scrollView.bounds.size.height);
+		CGFloat scrollOffsetThreshold = scrollOffsetThresholdMax-self.scrollView.bounds.size.height;
+		
         if(!self.scrollView.isDragging && self.state == SVInfiniteScrollingStateTriggered)
             self.state = SVInfiniteScrollingStateLoading;
         else if(contentOffset.y > scrollOffsetThreshold && self.state == SVInfiniteScrollingStateStopped && self.scrollView.isDragging)


### PR DESCRIPTION
On UIScrollView+SVInfiniteScrolling.m's 'scrollViewDidScroll:', scrollOffsetThreshold would calculate a negative value whenever the scroll view's content size was less than the scroll view's frame's height. Under such conditions, infinite scrolling would get triggered when scrolling upwards.
