### PR TITLE
Fix Pull to Refresh activates Infinite Scrolling

### DIFF
--- a/SVPullToRefresh.podspec
+++ b/SVPullToRefresh.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'SVPullToRefresh'
-  s.version  = '0.4.1'
+  s.version  = '0.4.2'
   s.platform = :ios, '5.0'
   s.license  = 'MIT'
   s.summary  = 'Give pull-to-refresh to any UIScrollView with 1 line of code.'

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -192,7 +192,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 }
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
-    if(self.state != SVInfiniteScrollingStateLoading && self.enabled) {
+    if(self.scrollView.contentOffset.y > 0 && self.state != SVInfiniteScrollingStateLoading && self.enabled) {
         CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
         CGFloat scrollOffsetThreshold = scrollViewContentHeight-self.scrollView.bounds.size.height;
         


### PR DESCRIPTION
# Fix #119
## Done
- Checking if `self.scrollView.contentOffset.y > 0` on `UIScrollView+SVInfiniteScrolling.m`:`scrollViewDidScroll:(CGPoint)contentOffset`
- Bumped the `CocoaPods` version to `0.1.42`

By checking if the content offset is greater than 0 we avoid triggering the infinite scrolling when doing the pull to refresh with small samples of data.

---

![http://i.giphy.com/yWnUyR27w6vvi.gif](http://i.giphy.com/yWnUyR27w6vvi.gif)
