### PR TITLE
added pullThresholdFactorProperty

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSUInteger, SVPullToRefreshState) {
 @property (nonatomic, readonly) SVPullToRefreshState state;
 @property (nonatomic, readonly) SVPullToRefreshPosition position;
 
+@property CGFloat pullThresholdFactor;
+
 - (void)setTitle:(NSString *)title forState:(SVPullToRefreshState)state;
 - (void)setSubtitle:(NSString *)subtitle forState:(SVPullToRefreshState)state;
 - (void)setCustomView:(UIView *)view forState:(SVPullToRefreshState)state;

--- a/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -158,7 +158,7 @@ static char UIScrollViewPullToRefreshView;
 @implementation SVPullToRefreshView
 
 // public properties
-@synthesize pullToRefreshActionHandler, arrowColor, textColor, activityIndicatorViewColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter;
+@synthesize pullToRefreshActionHandler, arrowColor, textColor, activityIndicatorViewColor, activityIndicatorViewStyle, lastUpdatedDate, dateFormatter, pullThresholdFactor;
 
 @synthesize state = _state;
 @synthesize scrollView = _scrollView;
@@ -188,6 +188,8 @@ static char UIScrollViewPullToRefreshView;
         self.subtitles = [NSMutableArray arrayWithObjects:@"", @"", @"", @"", nil];
         self.viewForState = [NSMutableArray arrayWithObjects:@"", @"", @"", @"", nil];
         self.wasTriggeredByUser = YES;
+        
+        self.pullThresholdFactor = 1.0f;
     }
     
     return self;
@@ -401,6 +403,8 @@ static char UIScrollViewPullToRefreshView;
                 scrollOffsetThreshold = MAX(self.scrollView.contentSize.height - self.scrollView.bounds.size.height, 0.0f) + self.bounds.size.height + self.originalBottomInset;
                 break;
         }
+        
+        scrollOffsetThreshold*=pullThresholdFactor;
         
         if(!self.scrollView.isDragging && self.state == SVPullToRefreshStateTriggered)
             self.state = SVPullToRefreshStateLoading;


### PR DESCRIPTION
this fixes the issue in [Issue #267](https://github.com/samvermette/SVPullToRefresh/issues/267) -

>  it always accidentally triggers when I scroll up to the top and the `scrollView` bounces

the `pullThresholdFactor` property allows to fine-tune how much you have to pull the `scrollView` to trigger the `pullToRefresh`. Default value is `1.0f`.
