### PR TITLE
fix infiniteScrollingView still appear when UIScrollView content size is shorter than screen

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -194,7 +194,7 @@ UIEdgeInsets scrollViewOriginalContentInsets;
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
     if(self.state != SVInfiniteScrollingStateLoading && self.enabled) {
         CGFloat scrollViewContentHeight = self.scrollView.contentSize.height;
-        CGFloat scrollOffsetThreshold = scrollViewContentHeight-self.scrollView.bounds.size.height;
+        CGFloat scrollOffsetThreshold = fabs(scrollViewContentHeight-self.scrollView.bounds.size.height);
         
         if(!self.scrollView.isDragging && self.state == SVInfiniteScrollingStateTriggered)
             self.state = SVInfiniteScrollingStateLoading;


### PR DESCRIPTION
when you have a blank tableView, if you trigger a pullToRefresh, the infiniteScrollingView will appear under pullToRefresh view. it should not be there in this circumstance.
