### PR TITLE
fix warning

### DIFF
--- a/Demo/SVPullToRefreshDemo/SVViewController.m
+++ b/Demo/SVPullToRefreshDemo/SVViewController.m
@@ -36,6 +36,7 @@
 }
 
 - (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
     [tableView triggerPullToRefresh];
 }
 


### PR DESCRIPTION
fix
”SVViewController.m:40:1: The 'viewDidAppear:' instance
method in UIViewController subclass 'SVViewController' is missing a
[super viewDidAppear:] call”
