### PR TITLE
Allow bottom inset to change

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.h
@@ -33,6 +33,7 @@ typedef NSUInteger SVInfiniteScrollingState;
 
 @interface SVInfiniteScrollingView : UIView
 
+@property (nonatomic, readwrite) CGFloat originalBottomInset;
 @property (nonatomic, readwrite) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 @property (nonatomic, readonly) SVInfiniteScrollingState state;
 @property (nonatomic, readwrite) BOOL enabled;

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -169,6 +169,19 @@ UIEdgeInsets scrollViewOriginalContentInsets;
     [self setScrollViewContentInset:currentInsets];
 }
 
+- (void)setOriginalBottomInset:(CGFloat)originalBottomInset {
+    if (_originalBottomInset != originalBottomInset) {
+        _originalBottomInset = originalBottomInset;
+        
+        if (self.isObserving) {
+            [self setScrollViewContentInsetForInfiniteScrolling];
+        }
+        else {
+            [self resetScrollViewContentInset];
+        }
+    }
+}
+
 - (void)setScrollViewContentInset:(UIEdgeInsets)contentInset {
     [UIView animateWithDuration:0.3
                           delay:0

--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -29,7 +29,6 @@ static CGFloat const SVInfiniteScrollingViewHeight = 60;
 @property (nonatomic, readwrite) SVInfiniteScrollingState state;
 @property (nonatomic, strong) NSMutableArray *viewForState;
 @property (nonatomic, weak) UIScrollView *scrollView;
-@property (nonatomic, readwrite) CGFloat originalBottomInset;
 @property (nonatomic, assign) BOOL wasTriggeredByUser;
 @property (nonatomic, assign) BOOL isObserving;
 


### PR DESCRIPTION
This exposes the originalBottomInset property of SVInfiniteScrollingView.

I used this in a project where I needed to show / hide the keyboard over an infinite scrolling view, and wanted to adjust the bottom scroll inset to make room for the keyboard.