### PR TITLE
- Fix UIActivityIndicatorView not show when calling startAnimating and hidesWhenStopped is true.

### DIFF
--- a/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
+++ b/SVPullToRefresh/UIScrollView+SVInfiniteScrolling.m
@@ -285,14 +285,17 @@ UIEdgeInsets scrollViewOriginalContentInsets;
         switch (newState) {
             case SVInfiniteScrollingStateStopped:
                 [self.activityIndicatorView stopAnimating];
+                self.activityIndicatorView.hidden = YES;
                 break;
                 
             case SVInfiniteScrollingStateTriggered:
                 [self.activityIndicatorView startAnimating];
+                self.activityIndicatorView.hidden = NO;
                 break;
                 
             case SVInfiniteScrollingStateLoading:
                 [self.activityIndicatorView startAnimating];
+                self.activityIndicatorView.hidden = NO;
                 break;
         }
     }


### PR DESCRIPTION
Apparently default infinite scrolling view's activity indicator view does not show when enter trigger state. It only shows when enter loading state. This commit fix the problem by manually set hidden property to NO when updating state of infinite scrolling view.